### PR TITLE
ntdll: Allow wine_nt_to_unix_file_name and wine_get_unix_file_name to work with hide wine exports disabled

### DIFF
--- a/dlls/ntdll/loader.c
+++ b/dlls/ntdll/loader.c
@@ -1871,7 +1871,7 @@ NTSTATUS WINAPI LdrGetProcedureAddress(HMODULE module, const ANSI_STRING *name,
     DWORD exp_size;
     NTSTATUS ret = STATUS_PROCEDURE_NOT_FOUND;
 
-    if(name && (!strcmp(name->Buffer, "wine_nt_to_unix_file_name") || !strcmp(name->Buffer, "wine_get_unix_file_name")))
+    if(name && (!strcmp(name->Buffer, "wine_nt_to_unix_file_name") || !strcmp(name->Buffer, "wine_get_unix_file_name")) && hide_wine_exports)
     {
         FIXME("skipping %s\n", name->Buffer);
         return ret;


### PR DESCRIPTION
This fixes `winepath` when hide wine exports are disabled
Tbh I don't think upstream will like this part of code anyways