### PR TITLE
Shared virtual timeline sempahore implementation + misc Halo Infinite fix

### DIFF
--- a/dlls/mfplat/Makefile.in
+++ b/dlls/mfplat/Makefile.in
@@ -1,6 +1,7 @@
 MODULE    = mfplat.dll
 IMPORTLIB = mfplat
-IMPORTS   = advapi32 ole32 mfuuid propsys rtworkq
+IMPORTS   = advapi32 ole32 mfuuid propsys rtworkq kernelbase
+DELAYIMPORTS = bcrypt
 
 EXTRADLLFLAGS = -Wb,--prefer-native
 

--- a/dlls/mfplat/main.c
+++ b/dlls/mfplat/main.c
@@ -6112,39 +6112,14 @@ static HRESULT resolver_create_registered_handler(HKEY hkey, REFIID riid, void *
     return hr;
 }
 
-static HRESULT resolver_get_bytestream_handler(IMFByteStream *stream, const WCHAR *url, DWORD flags,
-        IMFByteStreamHandler **handler)
+static HRESULT resolver_create_bytestream_handler(IMFByteStream *stream, DWORD flags, const WCHAR *mime,
+        const WCHAR *extension, IMFByteStreamHandler **handler)
 {
     static const HKEY hkey_roots[2] = { HKEY_CURRENT_USER, HKEY_LOCAL_MACHINE };
-    WCHAR *mimeW = NULL, *urlW = NULL;
-    IMFAttributes *attributes;
-    const WCHAR *url_ext;
     HRESULT hr = E_FAIL;
     unsigned int i, j;
-    UINT32 length;
 
     *handler = NULL;
-
-    /* MIME type */
-    if (SUCCEEDED(IMFByteStream_QueryInterface(stream, &IID_IMFAttributes, (void **)&attributes)))
-    {
-        IMFAttributes_GetAllocatedString(attributes, &MF_BYTESTREAM_CONTENT_TYPE, &mimeW, &length);
-        if (!url)
-        {
-            IMFAttributes_GetAllocatedString(attributes, &MF_BYTESTREAM_ORIGIN_NAME, &urlW, &length);
-            url = urlW;
-        }
-        IMFAttributes_Release(attributes);
-    }
-
-    /* Extension */
-    url_ext = url ? wcsrchr(url, '.') : NULL;
-
-    if (!url_ext && !mimeW)
-    {
-        CoTaskMemFree(urlW);
-        return MF_E_UNSUPPORTED_BYTESTREAM_TYPE;
-    }
 
     if (!(flags & MF_RESOLUTION_DISABLE_LOCAL_PLUGINS))
     {
@@ -6154,8 +6129,8 @@ static HRESULT resolver_get_bytestream_handler(IMFByteStream *stream, const WCHA
 
         LIST_FOR_EACH_ENTRY(local_handler, &local_bytestream_handlers, struct local_handler, entry)
         {
-            if ((mimeW && !lstrcmpiW(mimeW, local_handler->u.bytestream.mime))
-                    || (url_ext && !lstrcmpiW(url_ext, local_handler->u.bytestream.extension)))
+            if ((mime && !lstrcmpiW(mime, local_handler->u.bytestream.mime))
+                    || (extension && !lstrcmpiW(extension, local_handler->u.bytestream.extension)))
             {
                 if (SUCCEEDED(hr = IMFActivate_ActivateObject(local_handler->activate, &IID_IMFByteStreamHandler,
                         (void **)handler)))
@@ -6166,16 +6141,12 @@ static HRESULT resolver_get_bytestream_handler(IMFByteStream *stream, const WCHA
         LeaveCriticalSection(&local_handlers_section);
 
         if (*handler)
-        {
-            CoTaskMemFree(mimeW);
-            CoTaskMemFree(urlW);
             return hr;
-        }
     }
 
     for (i = 0, hr = E_FAIL; i < ARRAY_SIZE(hkey_roots); ++i)
     {
-        const WCHAR *namesW[2] = { mimeW, url_ext };
+        const WCHAR *namesW[2] = { mime, extension };
         HKEY hkey, hkey_handler;
 
         if (RegOpenKeyW(hkey_roots[i], L"Software\\Microsoft\\Windows Media Foundation\\ByteStreamHandlers", &hkey))
@@ -6202,14 +6173,161 @@ static HRESULT resolver_get_bytestream_handler(IMFByteStream *stream, const WCHA
             break;
     }
 
-    if (FAILED(hr))
+    return hr;
+}
+
+static HRESULT resolver_get_bytestream_url_hint(IMFByteStream *stream, WCHAR const **url)
+{
+    static const unsigned char asfmagic[]  = {0x30,0x26,0xb2,0x75,0x8e,0x66,0xcf,0x11,0xa6,0xd9,0x00,0xaa,0x00,0x62,0xce,0x6c};
+    static const unsigned char wavmagic[]  = { 'R', 'I', 'F', 'F',0x00,0x00,0x00,0x00, 'W', 'A', 'V', 'E', 'f', 'm', 't', ' '};
+    static const unsigned char wavmask[]   = {0xff,0xff,0xff,0xff,0x00,0x00,0x00,0x00,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff};
+    static const unsigned char isommagic[] = {0x00,0x00,0x00,0x00, 'f', 't', 'y', 'p', 'i', 's', 'o', 'm',0x00,0x00,0x00,0x00};
+    static const unsigned char mp4_magic[] = {0x00,0x00,0x00,0x00, 'f', 't', 'y', 'p', 'M', 'S', 'N', 'V',0x00,0x00,0x00,0x00};
+    static const unsigned char mp42magic[] = {0x00,0x00,0x00,0x00, 'f', 't', 'y', 'p', 'm', 'p', '4', '2',0x00,0x00,0x00,0x00};
+    static const unsigned char mp4vmagic[] = {0x00,0x00,0x00,0x00, 'f', 't', 'y', 'p', 'M', '4', 'V', ' ',0x00,0x00,0x00,0x00};
+    static const unsigned char mp4mask[]   = {0x00,0x00,0x00,0x00,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0x00,0x00,0x00,0x00};
+    static const struct stream_content_url_hint
     {
-        static const GUID CLSID_GStreamerByteStreamHandler = {0x317df618, 0x5e5a, 0x468a, {0x9f, 0x15, 0xd8, 0x27, 0xa9, 0xa0, 0x81, 0x62}};
-        hr = CoCreateInstance(&CLSID_GStreamerByteStreamHandler, NULL, CLSCTX_INPROC_SERVER, &IID_IMFByteStreamHandler, (void **)handler);
+        const unsigned char *magic;
+        const WCHAR *url;
+        const unsigned char *mask;
+    }
+    url_hints[] =
+    {
+        { asfmagic,  L".asf" },
+        { wavmagic,  L".wav", wavmask },
+        { isommagic, L".mp4", mp4mask },
+        { mp42magic, L".mp4", mp4mask },
+        { mp4_magic, L".mp4", mp4mask },
+        { mp4vmagic, L".m4v", mp4mask },
+    };
+    unsigned char buffer[4 * sizeof(unsigned int)], pattern[4 * sizeof(unsigned int)];
+    IMFAttributes *attributes;
+    DWORD length = 0, caps = 0;
+    unsigned int i, j;
+    QWORD position;
+    HRESULT hr;
+
+    *url = NULL;
+
+    if (SUCCEEDED(IMFByteStream_QueryInterface(stream, &IID_IMFAttributes, (void **)&attributes)))
+    {
+        UINT32 string_length = 0;
+        IMFAttributes_GetStringLength(attributes, &MF_BYTESTREAM_CONTENT_TYPE, &string_length);
+        IMFAttributes_Release(attributes);
+
+        if (string_length)
+            return S_OK;
+    }
+
+    if (FAILED(hr = IMFByteStream_GetCapabilities(stream, &caps)))
+        return hr;
+
+    if (!(caps & MFBYTESTREAM_IS_SEEKABLE))
+        return MF_E_UNSUPPORTED_BYTESTREAM_TYPE;
+
+    if (FAILED(hr = IMFByteStream_GetCurrentPosition(stream, &position)))
+        return hr;
+
+    hr = IMFByteStream_Read(stream, buffer, sizeof(buffer), &length);
+    IMFByteStream_SetCurrentPosition(stream, position);
+    if (FAILED(hr))
+        return hr;
+
+    if (length < sizeof(buffer))
+        return S_OK;
+
+    for (i = 0; i < ARRAY_SIZE(url_hints); ++i)
+    {
+        memcpy(pattern, buffer, sizeof(buffer));
+        if (url_hints[i].mask)
+        {
+            unsigned int *mask = (unsigned int *)url_hints[i].mask;
+            unsigned int *data = (unsigned int *)pattern;
+
+            for (j = 0; j < sizeof(buffer) / sizeof(unsigned int); ++j)
+                data[j] &= mask[j];
+
+        }
+        if (!memcmp(pattern, url_hints[i].magic, sizeof(pattern)))
+        {
+            *url = url_hints[i].url;
+            break;
+        }
+    }
+
+    if (*url)
+        TRACE("Content type guessed as %s from %s.\n", debugstr_w(*url), debugstr_an((char *)buffer, length));
+    else
+        WARN("Unrecognized content type %s.\n", debugstr_an((char *)buffer, length));
+
+    return S_OK;
+}
+
+static HRESULT resolver_create_gstreamer_handler(IMFByteStreamHandler **handler)
+{
+    static const GUID CLSID_GStreamerByteStreamHandler = {0x317df618, 0x5e5a, 0x468a, {0x9f, 0x15, 0xd8, 0x27, 0xa9, 0xa0, 0x81, 0x62}};
+    return CoCreateInstance(&CLSID_GStreamerByteStreamHandler, NULL, CLSCTX_INPROC_SERVER, &IID_IMFByteStreamHandler, (void **)handler);
+}
+
+static HRESULT resolver_get_bytestream_handler(IMFByteStream *stream, const WCHAR *url, DWORD flags,
+        IMFByteStreamHandler **handler)
+{
+    WCHAR *mimeW = NULL, *urlW = NULL;
+    IMFAttributes *attributes;
+    const WCHAR *url_ext;
+    HRESULT hr = E_FAIL;
+    UINT32 length;
+
+    *handler = NULL;
+
+    /* MIME type */
+    if (SUCCEEDED(IMFByteStream_QueryInterface(stream, &IID_IMFAttributes, (void **)&attributes)))
+    {
+        IMFAttributes_GetAllocatedString(attributes, &MF_BYTESTREAM_CONTENT_TYPE, &mimeW, &length);
+        if (!url)
+        {
+            IMFAttributes_GetAllocatedString(attributes, &MF_BYTESTREAM_ORIGIN_NAME, &urlW, &length);
+            url = urlW;
+        }
+        IMFAttributes_Release(attributes);
+    }
+
+    /* Extension */
+    url_ext = url ? wcsrchr(url, '.') : NULL;
+
+    /* If content type was provided by the caller, it's tried first. Otherwise an attempt to deduce
+       content type from the content itself is made.
+
+       TODO: wine specific fallback to predefined handler could be replaced by normally registering
+       this handler for all possible types.
+     */
+
+    if (url_ext || mimeW)
+    {
+        hr = resolver_create_bytestream_handler(stream, flags, mimeW, url_ext, handler);
+
+        if (FAILED(hr))
+            hr = resolver_create_gstreamer_handler(handler);
     }
 
     CoTaskMemFree(mimeW);
     CoTaskMemFree(urlW);
+
+    if (SUCCEEDED(hr))
+        return hr;
+
+    if (!(flags & MF_RESOLUTION_CONTENT_DOES_NOT_HAVE_TO_MATCH_EXTENSION_OR_MIME_TYPE))
+        return MF_E_UNSUPPORTED_BYTESTREAM_TYPE;
+
+    if (FAILED(hr = resolver_get_bytestream_url_hint(stream, &url_ext)))
+        return hr;
+
+    hr = resolver_create_bytestream_handler(stream, flags, NULL, url_ext, handler);
+
+    if (FAILED(hr))
+        hr = resolver_create_gstreamer_handler(handler);
+
     return hr;
 }
 

--- a/dlls/mfplat/main.c
+++ b/dlls/mfplat/main.c
@@ -52,6 +52,9 @@
 #include "initguid.h"
 #include "mfd3d12.h"
 
+#include "bcrypt.h"
+#include "pathcch.h"
+
 WINE_DEFAULT_DEBUG_CHANNEL(mfplat);
 
 struct local_handler
@@ -4529,11 +4532,8 @@ static const IMFGetServiceVtbl bytestream_file_getservice_vtbl =
     bytestream_file_getservice_GetService,
 };
 
-/***********************************************************************
- *      MFCreateFile (mfplat.@)
- */
-HRESULT WINAPI MFCreateFile(MF_FILE_ACCESSMODE accessmode, MF_FILE_OPENMODE openmode, MF_FILE_FLAGS flags,
-                            LPCWSTR url, IMFByteStream **bytestream)
+static HRESULT create_file_bytestream(MF_FILE_ACCESSMODE accessmode, MF_FILE_OPENMODE openmode, MF_FILE_FLAGS flags,
+        const WCHAR *path, BOOL is_tempfile, IMFByteStream **bytestream)
 {
     DWORD capabilities = MFBYTESTREAM_IS_SEEKABLE | MFBYTESTREAM_DOES_NOT_USE_NETWORK;
     DWORD filecreation_disposition = 0, fileaccessmode = 0, fileattributes = 0;
@@ -4542,8 +4542,6 @@ HRESULT WINAPI MFCreateFile(MF_FILE_ACCESSMODE accessmode, MF_FILE_OPENMODE open
     FILETIME writetime;
     HANDLE file;
     HRESULT hr;
-
-    TRACE("%d, %d, %#x, %s, %p.\n", accessmode, openmode, flags, debugstr_w(url), bytestream);
 
     switch (accessmode)
     {
@@ -4583,12 +4581,12 @@ HRESULT WINAPI MFCreateFile(MF_FILE_ACCESSMODE accessmode, MF_FILE_OPENMODE open
 
     if (flags & MF_FILEFLAGS_NOBUFFERING)
         fileattributes |= FILE_FLAG_NO_BUFFERING;
+    if (is_tempfile)
+        fileattributes |= FILE_FLAG_DELETE_ON_CLOSE;
 
     /* Open HANDLE to file */
-    file = CreateFileW(url, fileaccessmode, filesharemode, NULL,
-                       filecreation_disposition, fileattributes, 0);
-
-    if(file == INVALID_HANDLE_VALUE)
+    file = CreateFileW(path, fileaccessmode, filesharemode, NULL, filecreation_disposition, fileattributes, 0);
+    if (file == INVALID_HANDLE_VALUE)
         return HRESULT_FROM_WIN32(GetLastError());
 
     if (!(object = calloc(1, sizeof(*object))))
@@ -4613,17 +4611,59 @@ HRESULT WINAPI MFCreateFile(MF_FILE_ACCESSMODE accessmode, MF_FILE_OPENMODE open
     object->capabilities = capabilities;
     object->hfile = file;
 
-    if (GetFileTime(file, NULL, NULL, &writetime))
+    if (!is_tempfile && GetFileTime(file, NULL, NULL, &writetime))
     {
         IMFAttributes_SetBlob(&object->attributes.IMFAttributes_iface, &MF_BYTESTREAM_LAST_MODIFIED_TIME,
                 (const UINT8 *)&writetime, sizeof(writetime));
     }
 
-    IMFAttributes_SetString(&object->attributes.IMFAttributes_iface, &MF_BYTESTREAM_ORIGIN_NAME, url);
+    IMFAttributes_SetString(&object->attributes.IMFAttributes_iface, &MF_BYTESTREAM_ORIGIN_NAME, path);
 
     *bytestream = &object->IMFByteStream_iface;
 
     return S_OK;
+}
+
+/***********************************************************************
+ *      MFCreateFile (mfplat.@)
+ */
+HRESULT WINAPI MFCreateFile(MF_FILE_ACCESSMODE accessmode, MF_FILE_OPENMODE openmode, MF_FILE_FLAGS flags,
+        const WCHAR *path, IMFByteStream **bytestream)
+{
+    TRACE("%d, %d, %#x, %s, %p.\n", accessmode, openmode, flags, debugstr_w(path), bytestream);
+
+    return create_file_bytestream(accessmode, openmode, flags, path, FALSE, bytestream);
+}
+
+/***********************************************************************
+ *      MFCreateTempFile (mfplat.@)
+ */
+HRESULT WINAPI MFCreateTempFile(MF_FILE_ACCESSMODE accessmode, MF_FILE_OPENMODE openmode, MF_FILE_FLAGS flags,
+        IMFByteStream **bytestream)
+{
+    WCHAR name[24], tmppath[MAX_PATH], *path;
+    ULONG64 rnd;
+    size_t len;
+    HRESULT hr;
+
+    TRACE("%d, %d, %#x, %p.\n", accessmode, openmode, flags, bytestream);
+
+    BCryptGenRandom(NULL, (UCHAR *)&rnd, sizeof(rnd), BCRYPT_USE_SYSTEM_PREFERRED_RNG);
+    swprintf(name, ARRAY_SIZE(name), L"MFP%llX.TMP", rnd);
+    GetTempPathW(ARRAY_SIZE(tmppath), tmppath);
+
+    len = wcslen(tmppath) + wcslen(name) + 2;
+    if (!(path = malloc(len * sizeof(*path))))
+        return E_OUTOFMEMORY;
+
+    wcscpy(path, tmppath);
+    PathCchAppend(path, len, name);
+
+    hr = create_file_bytestream(accessmode, openmode, flags, path, TRUE, bytestream);
+
+    free(path);
+
+    return hr;
 }
 
 struct bytestream_wrapper

--- a/dlls/mfplat/mfplat.spec
+++ b/dlls/mfplat/mfplat.spec
@@ -71,7 +71,7 @@
 @ stdcall MFCreateStreamDescriptor(long long ptr ptr)
 @ stdcall MFCreateSystemTimeSource(ptr)
 @ stub MFCreateSystemUnderlyingClock
-@ stub MFCreateTempFile
+@ stdcall MFCreateTempFile(long long long ptr)
 @ stdcall MFCreateTrackedSample(ptr)
 @ stdcall MFCreateTransformActivate(ptr)
 @ stub MFCreateURLFromPath

--- a/dlls/ntdll/unix/fsync.c
+++ b/dlls/ntdll/unix/fsync.c
@@ -225,27 +225,18 @@ C_ASSERT(sizeof(struct mutex) == 16);
 
 static char shm_name[29];
 static int shm_fd;
-static void **shm_addrs;
-static int shm_addrs_size;  /* length of the allocated shm_addrs array */
-
-static pthread_mutex_t shm_addrs_mutex = PTHREAD_MUTEX_INITIALIZER;
+static volatile void *shm_addrs[8192];
 
 static void *get_shm( unsigned int idx )
 {
     int entry  = (idx * 16) / FSYNC_SHM_PAGE_SIZE;
     int offset = (idx * 16) % FSYNC_SHM_PAGE_SIZE;
-    void *ret;
 
-    pthread_mutex_lock( &shm_addrs_mutex );
-
-    if (entry >= shm_addrs_size)
+    if (entry >= ARRAY_SIZE(shm_addrs))
     {
-        int new_size = max(shm_addrs_size * 2, entry + 1);
-
-        if (!(shm_addrs = realloc( shm_addrs, new_size * sizeof(shm_addrs[0]) )))
-            ERR("Failed to grow shm_addrs array to size %d.\n", shm_addrs_size);
-        memset( shm_addrs + shm_addrs_size, 0, (new_size - shm_addrs_size) * sizeof(shm_addrs[0]) );
-        shm_addrs_size = new_size;
+        ERR( "idx %u exceeds maximum of %u.\n", idx,
+             (unsigned int)ARRAY_SIZE(shm_addrs) * (FSYNC_SHM_PAGE_SIZE / 16) );
+        return NULL;
     }
 
     if (!shm_addrs[entry])
@@ -262,11 +253,7 @@ static void *get_shm( unsigned int idx )
             munmap( addr, FSYNC_SHM_PAGE_SIZE ); /* someone beat us to it */
     }
 
-    ret = (void *)((unsigned long)shm_addrs[entry] + offset);
-
-    pthread_mutex_unlock( &shm_addrs_mutex );
-
-    return ret;
+    return (char *)shm_addrs[entry] + offset;
 }
 
 /* We'd like lookup to be fast. To that end, we use a static list indexed by handle.
@@ -344,10 +331,9 @@ static void grab_object( struct fsync *obj )
 
 static unsigned int shm_index_from_shm( char *shm )
 {
-    unsigned int count = shm_addrs_size;
     unsigned int i, idx_offset;
 
-    for (i = 0; i < count; ++i)
+    for (i = 0; i < ARRAY_SIZE(shm_addrs); ++i)
     {
         if (shm >= (char *)shm_addrs[i] && shm < (char *)shm_addrs[i] + FSYNC_SHM_PAGE_SIZE)
         {
@@ -597,9 +583,6 @@ void fsync_init(void)
             ERR("Failed to initialize shared memory: %s\n", strerror( errno ));
         exit(1);
     }
-
-    shm_addrs = calloc( 128, sizeof(shm_addrs[0]) );
-    shm_addrs_size = 128;
 }
 
 NTSTATUS fsync_create_semaphore( HANDLE *handle, ACCESS_MASK access,

--- a/dlls/ntoskrnl.exe/ntoskrnl.c
+++ b/dlls/ntoskrnl.exe/ntoskrnl.c
@@ -260,6 +260,15 @@ POBJECT_TYPE WINAPI ObGetObjectType( void *object )
     return header->type;
 }
 
+static const WCHAR section_type_name[] = {'S','e','c','t','i','o','n',0};
+
+static struct _OBJECT_TYPE section_type =
+{
+    section_type_name
+};
+
+static POBJECT_TYPE p_section_type = &section_type;
+
 static const POBJECT_TYPE *known_types[] =
 {
     &ExEventObjectType,
@@ -269,7 +278,8 @@ static const POBJECT_TYPE *known_types[] =
     &IoFileObjectType,
     &PsProcessType,
     &PsThreadType,
-    &SeTokenObjectType
+    &SeTokenObjectType,
+    &p_section_type,
 };
 
 DECLARE_CRITICAL_SECTION(handle_map_cs);

--- a/dlls/sharedgpures.sys/shared_resource.c
+++ b/dlls/sharedgpures.sys/shared_resource.c
@@ -25,6 +25,8 @@ struct shared_resource
     WCHAR *name;
     void *metadata;
     SIZE_T metadata_size;
+    void **object_pool;
+    unsigned int object_pool_count;
 };
 
 static struct shared_resource *resource_pool;
@@ -275,6 +277,70 @@ static NTSTATUS shared_resource_get_metadata(struct shared_resource *res, void *
     return STATUS_SUCCESS;
 }
 
+#define IOCTL_SHARED_GPU_RESOURCE_SET_OBJECT           CTL_CODE(FILE_DEVICE_VIDEO, 6, METHOD_BUFFERED, FILE_WRITE_ACCESS)
+
+struct shared_resource_set_object
+{
+    unsigned int index;
+    obj_handle_t handle;
+};
+
+static NTSTATUS shared_resource_set_object(struct shared_resource *res, void *buff, SIZE_T insize, IO_STATUS_BLOCK *iosb)
+{
+    struct shared_resource_set_object *params = buff;
+    void *object;
+
+    if (insize < sizeof(*params))
+        return STATUS_INFO_LENGTH_MISMATCH;
+
+    if (!(object = reference_client_handle(params->handle)))
+        return STATUS_INVALID_HANDLE;
+
+    if (params->index >= res->object_pool_count)
+    {
+        void **expanded_pool = ExAllocatePoolWithTag(NonPagedPool, (params->index + 1) * sizeof(void *), 0);
+
+        if (res->object_pool)
+        {
+            memcpy(expanded_pool, res->object_pool, res->object_pool_count * sizeof(void *));
+            ExFreePoolWithTag(res->object_pool, 0);
+        }
+
+        memset(&expanded_pool[res->object_pool_count], 0, (params->index + 1 - res->object_pool_count) * sizeof (void *));
+
+        res->object_pool = expanded_pool;
+        res->object_pool_count = params->index + 1;
+    }
+
+    if (res->object_pool[params->index])
+        ObDereferenceObject(res->object_pool[params->index]);
+
+    res->object_pool[params->index] = object;
+
+    iosb->Information = 0;
+    return STATUS_SUCCESS;
+}
+
+#define IOCTL_SHARED_GPU_RESOURCE_GET_OBJECT           CTL_CODE(FILE_DEVICE_VIDEO, 6, METHOD_BUFFERED, FILE_READ_ACCESS)
+
+static NTSTATUS shared_resource_get_object(struct shared_resource *res, void *buff, SIZE_T insize, SIZE_T outsize, IO_STATUS_BLOCK *iosb)
+{
+    unsigned int index;
+
+    if (insize < sizeof(unsigned int) || outsize < sizeof(obj_handle_t))
+        return STATUS_INFO_LENGTH_MISMATCH;
+
+    index = *(unsigned int *)buff;
+
+    if (index >= res->object_pool_count || !res->object_pool[index])
+        return STATUS_INVALID_PARAMETER;
+
+    *((obj_handle_t *)buff) = open_client_handle(res->object_pool[index]);
+
+    iosb->Information = sizeof(obj_handle_t);
+    return STATUS_SUCCESS;
+}
+
 static NTSTATUS WINAPI dispatch_create(DEVICE_OBJECT *device, IRP *irp)
 {
     irp->IoStatus.u.Status = STATUS_SUCCESS;
@@ -304,6 +370,18 @@ static NTSTATUS WINAPI dispatch_close(DEVICE_OBJECT *device, IRP *irp)
             {
                 ExFreePoolWithTag(res->metadata, 0);
                 res->metadata = NULL;
+            }
+            if (res->object_pool)
+            {
+                unsigned int i;
+                for (i = 0; i < res->object_pool_count; i++)
+                {
+                    if (res->object_pool[i])
+                        ObDereferenceObject(res->object_pool[i]);
+                }
+                ExFreePoolWithTag(res->object_pool, 0);
+                res->object_pool = NULL;
+                res->object_pool_count = 0;
             }
         }
     }
@@ -361,6 +439,19 @@ static NTSTATUS WINAPI dispatch_ioctl(DEVICE_OBJECT *device, IRP *irp)
                                       irp->AssociatedIrp.SystemBuffer,
                                       stack->Parameters.DeviceIoControl.OutputBufferLength,
                                       &irp->IoStatus );
+            break;
+        case IOCTL_SHARED_GPU_RESOURCE_SET_OBJECT:
+            status = shared_resource_set_object( res,
+                                      irp->AssociatedIrp.SystemBuffer,
+                                      stack->Parameters.DeviceIoControl.InputBufferLength,
+                                      &irp->IoStatus );
+            break;
+        case IOCTL_SHARED_GPU_RESOURCE_GET_OBJECT:
+            status = shared_resource_get_object( res,
+                                      irp->AssociatedIrp.SystemBuffer,
+                                      stack->Parameters.DeviceIoControl.InputBufferLength,
+                                      stack->Parameters.DeviceIoControl.OutputBufferLength,
+                                      &irp->IoStatus);
             break;
     default:
         FIXME( "ioctl %lx not supported\n", stack->Parameters.DeviceIoControl.IoControlCode );

--- a/dlls/sharedgpures.sys/shared_resource.c
+++ b/dlls/sharedgpures.sys/shared_resource.c
@@ -285,7 +285,7 @@ static NTSTATUS WINAPI dispatch_create(DEVICE_OBJECT *device, IRP *irp)
 static NTSTATUS WINAPI dispatch_close(DEVICE_OBJECT *device, IRP *irp)
 {
     IO_STACK_LOCATION *stack = IoGetCurrentIrpStackLocation(irp);
-    struct shared_resource *res = stack->FileObject->FsContext;
+    struct shared_resource *res = &resource_pool[ (UINT_PTR) stack->FileObject->FsContext ];
 
     TRACE("Freeing shared resouce %p.\n", res);
 
@@ -316,7 +316,7 @@ static NTSTATUS WINAPI dispatch_close(DEVICE_OBJECT *device, IRP *irp)
 static NTSTATUS WINAPI dispatch_ioctl(DEVICE_OBJECT *device, IRP *irp)
 {
     IO_STACK_LOCATION *stack = IoGetCurrentIrpStackLocation( irp );
-    struct shared_resource **res = (struct shared_resource **) &stack->FileObject->FsContext;
+    struct shared_resource *res = &resource_pool[ (UINT_PTR) stack->FileObject->FsContext ];
     NTSTATUS status;
 
     TRACE( "ioctl %lx insize %lu outsize %lu\n",
@@ -327,37 +327,37 @@ static NTSTATUS WINAPI dispatch_ioctl(DEVICE_OBJECT *device, IRP *irp)
     switch (stack->Parameters.DeviceIoControl.IoControlCode)
     {
         case IOCTL_SHARED_GPU_RESOURCE_CREATE:
-            status = shared_resource_create( res,
+            status = shared_resource_create( &res,
                                       irp->AssociatedIrp.SystemBuffer,
                                       stack->Parameters.DeviceIoControl.InputBufferLength,
                                       &irp->IoStatus );
             break;
         case IOCTL_SHARED_GPU_RESOURCE_OPEN:
-            status = shared_resource_open( res,
+            status = shared_resource_open( &res,
                                       irp->AssociatedIrp.SystemBuffer,
                                       stack->Parameters.DeviceIoControl.InputBufferLength,
                                       &irp->IoStatus );
             break;
         case IOCTL_SHARED_GPU_RESOURCE_GETKMT:
-            status = shared_resource_getkmt( *res,
+            status = shared_resource_getkmt( res,
                                       irp->AssociatedIrp.SystemBuffer,
                                       stack->Parameters.DeviceIoControl.OutputBufferLength,
                                       &irp->IoStatus );
             break;
         case IOCTL_SHARED_GPU_RESOURCE_GET_UNIX_RESOURCE:
-            status = shared_resource_get_unix_resource( *res,
+            status = shared_resource_get_unix_resource( res,
                                       irp->AssociatedIrp.SystemBuffer,
                                       stack->Parameters.DeviceIoControl.OutputBufferLength,
                                       &irp->IoStatus );
             break;
         case IOCTL_SHARED_GPU_RESOURCE_SET_METADATA:
-            status = shared_resource_set_metadata( *res,
+            status = shared_resource_set_metadata( res,
                                       irp->AssociatedIrp.SystemBuffer,
                                       stack->Parameters.DeviceIoControl.InputBufferLength,
                                       &irp->IoStatus );
             break;
         case IOCTL_SHARED_GPU_RESOURCE_GET_METADATA:
-            status = shared_resource_get_metadata( *res,
+            status = shared_resource_get_metadata( res,
                                       irp->AssociatedIrp.SystemBuffer,
                                       stack->Parameters.DeviceIoControl.OutputBufferLength,
                                       &irp->IoStatus );
@@ -367,6 +367,9 @@ static NTSTATUS WINAPI dispatch_ioctl(DEVICE_OBJECT *device, IRP *irp)
         status = STATUS_NOT_SUPPORTED;
         break;
     }
+
+    if (!status)
+        stack->FileObject->FsContext = (UINT_PTR)(res - resource_pool);
 
     irp->IoStatus.u.Status = status;
     IoCompleteRequest( irp, IO_NO_INCREMENT );

--- a/dlls/winegstreamer/media_source.c
+++ b/dlls/winegstreamer/media_source.c
@@ -882,6 +882,9 @@ static HRESULT media_stream_init_desc(struct media_stream *stream)
         IMFMediaType *base_type = mf_media_type_from_wg_format(&format);
         GUID base_subtype;
 
+        if (!base_type)
+            goto done;
+
         IMFMediaType_GetGUID(base_type, &MF_MT_SUBTYPE, &base_subtype);
 
         stream_types[0] = base_type;
@@ -914,8 +917,8 @@ static HRESULT media_stream_init_desc(struct media_stream *stream)
             WG_AUDIO_FORMAT_F32LE,
         };
 
-        stream_types[0] = mf_media_type_from_wg_format(&format);
-        type_count = 1;
+        if ((stream_types[0] = mf_media_type_from_wg_format(&format)))
+            type_count = 1;
 
         for (i = 0; i < ARRAY_SIZE(audio_types); i++)
         {
@@ -924,7 +927,8 @@ static HRESULT media_stream_init_desc(struct media_stream *stream)
                 continue;
             new_format = format;
             new_format.u.audio.format = audio_types[i];
-            stream_types[type_count++] = mf_media_type_from_wg_format(&new_format);
+            if ((stream_types[type_count] = mf_media_type_from_wg_format(&new_format)))
+                type_count++;
         }
     }
     else

--- a/dlls/winegstreamer/media_source.c
+++ b/dlls/winegstreamer/media_source.c
@@ -885,6 +885,8 @@ static HRESULT media_stream_init_desc(struct media_stream *stream)
         if (!base_type)
             goto done;
 
+        IMFMediaType_SetUINT32(base_type, &MF_MT_VIDEO_NOMINAL_RANGE, MFNominalRange_Normal);
+
         IMFMediaType_GetGUID(base_type, &MF_MT_SUBTYPE, &base_subtype);
 
         stream_types[0] = base_type;

--- a/dlls/winevulkan/loader.c
+++ b/dlls/winevulkan/loader.c
@@ -327,15 +327,22 @@ static void wait_graphics_driver_ready(void)
 
 static void fill_luid_property(VkPhysicalDeviceProperties2 *properties2)
 {
+    VkPhysicalDeviceVulkan11Properties *vk11;
+    VkBool32 device_luid_valid = VK_FALSE;
     VkPhysicalDeviceIDProperties *id;
+    uint32_t device_node_mask = 0;
     SP_DEVINFO_DATA device_data;
+    const uint8_t* device_uuid;
     DWORD type, device_idx = 0;
     HDEVINFO devinfo;
     HANDLE mutex;
     GUID uuid;
     LUID luid;
 
-    if (!(id = wine_vk_find_struct(properties2, PHYSICAL_DEVICE_ID_PROPERTIES)))
+    vk11 = wine_vk_find_struct(properties2, PHYSICAL_DEVICE_VULKAN_1_1_PROPERTIES);
+    id = wine_vk_find_struct(properties2, PHYSICAL_DEVICE_ID_PROPERTIES);
+
+    if (!vk11 && !id)
         return;
 
     wait_graphics_driver_ready();
@@ -348,15 +355,30 @@ static void fill_luid_property(VkPhysicalDeviceProperties2 *properties2)
                 &type, (BYTE *)&uuid, sizeof(uuid), NULL, 0))
             continue;
 
-        if (!IsEqualGUID(&uuid, id->deviceUUID))
+        device_uuid = id ? id->deviceUUID : vk11->deviceUUID;
+
+        if (!IsEqualGUID(&uuid, device_uuid))
             continue;
 
         if (SetupDiGetDevicePropertyW(devinfo, &device_data, &DEVPROPKEY_GPU_LUID, &type,
                 (BYTE *)&luid, sizeof(luid), NULL, 0))
         {
-            memcpy(&id->deviceLUID, &luid, sizeof(id->deviceLUID));
-            id->deviceLUIDValid = VK_TRUE;
-            id->deviceNodeMask = 1;
+            device_luid_valid = VK_TRUE;
+            device_node_mask = 1;
+
+            if (id)
+            {
+                memcpy(&id->deviceLUID, &luid, sizeof(id->deviceLUID));
+                id->deviceLUIDValid = device_luid_valid;
+                id->deviceNodeMask = device_node_mask;
+            }
+
+            if (vk11)
+            {
+                memcpy(&vk11->deviceLUID, &luid, sizeof(vk11->deviceLUID));
+                vk11->deviceLUIDValid = device_luid_valid;
+                vk11->deviceNodeMask = device_node_mask;
+            }
             break;
         }
     }
@@ -364,8 +386,8 @@ static void fill_luid_property(VkPhysicalDeviceProperties2 *properties2)
     release_display_device_init_mutex(mutex);
 
     TRACE("deviceName:%s deviceLUIDValid:%d LUID:%08lx:%08lx deviceNodeMask:%#x.\n",
-            properties2->properties.deviceName, id->deviceLUIDValid, luid.HighPart, luid.LowPart,
-            id->deviceNodeMask);
+            properties2->properties.deviceName, device_luid_valid, luid.HighPart, luid.LowPart,
+            device_node_mask);
 }
 
 static void fixup_device_id(VkPhysicalDeviceProperties *properties)

--- a/dlls/winevulkan/make_vulkan
+++ b/dlls/winevulkan/make_vulkan
@@ -324,6 +324,8 @@ STRUCT_CHAIN_CONVERSIONS = {
     "VkPhysicalDeviceImageFormatInfo2": [],
     "VkPhysicalDeviceExternalSemaphoreInfo": [],
     "VkSemaphoreCreateInfo": ["VK_STRUCTURE_TYPE_EXPORT_SEMAPHORE_WIN32_HANDLE_INFO_KHR"],
+    "VkSubmitInfo": ["VK_STRUCTURE_TYPE_D3D12_FENCE_SUBMIT_INFO_KHR"],
+    "VkSubmitInfo2" : [],
 }
 
 
@@ -1287,9 +1289,10 @@ class VkMember(object):
         return VkMember(const=const, struct_fwd_decl=struct_fwd_decl, _type=member_type, pointer=pointer, name=name_elem.text,
                 array_len=array_len, dyn_array_len=dyn_array_len, optional=optional, values=values, object_type=object_type, bit_width=bit_width)
 
-    def copy(self, input, output, direction, conv):
+    def copy(self, input, output, direction, conv, deep_copy=False):
         """ Helper method for use by conversion logic to generate a C-code statement to copy this member.
-            - `conv` indicates whether the statement is in a struct alignment conversion path. """
+            - `conv` indicates whether the statement is in a struct alignment conversion path.
+            - `deep_copy` indicates whether a pointers members need to have their data copied. """
 
         if (conv and self.needs_conversion()) or self.needs_unwrapping():
             if self.is_dynamic_array():
@@ -1327,6 +1330,9 @@ class VkMember(object):
         elif self.is_static_array():
             bytes_count = "{0} * sizeof({1})".format(self.array_len, self.type)
             return "memcpy({0}{1}, {2}{1}, {3});\n".format(output, self.name, input, bytes_count)
+        elif deep_copy and self.is_dynamic_array():
+            count = self.dyn_array_len if isinstance(self.dyn_array_len, int) else "{0}{1}".format(input, self.dyn_array_len)
+            return "{0}{1} = memdup({2}{1}, {3}, sizeof({0}{1}[0]));\n".format(output, self.name, input, count)
         else:
             return "{0}{1} = {2}{1};\n".format(output, self.name, input)
 
@@ -2576,10 +2582,11 @@ class FreeFunction(object):
 
 
 class StructChainConversionFunction(object):
-    def __init__(self, direction, struct, ignores):
+    def __init__(self, direction, struct, ignores, deep_copy):
         self.direction = direction
         self.struct = struct
         self.ignores = ignores
+        self.deep_copy = deep_copy
         self.type = struct.name
 
         self.name = "convert_{0}_struct_chain".format(self.type)
@@ -2629,8 +2636,8 @@ class StructChainConversionFunction(object):
                 if m.name == "pNext":
                     body += "            out->pNext = NULL;\n"
                 else:
-                    convert = m.copy("in->", "out->", self.direction, conv=True)
-                    unwrap = m.copy("in->", "out->", self.direction, conv=False)
+                    convert = m.copy("in->", "out->", self.direction, conv=True, deep_copy=self.deep_copy)
+                    unwrap = m.copy("in->", "out->", self.direction, conv=False, deep_copy=self.deep_copy)
                     if unwrap == convert:
                         body += "            " + unwrap
                     else:
@@ -2766,7 +2773,8 @@ class VkGenerator(object):
 
         for struct in self.registry.structs:
             if struct.name in STRUCT_CHAIN_CONVERSIONS:
-                self.struct_chain_conversions.append(StructChainConversionFunction(Direction.INPUT, struct, STRUCT_CHAIN_CONVERSIONS[struct.name]))
+                self.struct_chain_conversions.append(StructChainConversionFunction(Direction.INPUT, struct, STRUCT_CHAIN_CONVERSIONS[struct.name],
+                                                                                   struct.name == "VkSubmitInfo" or struct.name == "VkSubmitInfo2"))
                 self.struct_chain_conversions.append(FreeStructChainFunction(struct))
                 # Once we decide to support pNext chains conversion everywhere, move this under get_conversions
                 for e in struct.struct_extensions:

--- a/dlls/winevulkan/make_vulkan
+++ b/dlls/winevulkan/make_vulkan
@@ -214,6 +214,7 @@ FUNCTION_OVERRIDES = {
     "vkCreateBuffer" : {"dispatch" : True, "driver" : False, "thunk" : ThunkType.NONE},
     "vkCreateCommandPool" : {"dispatch": True, "driver" : False, "thunk" : ThunkType.NONE},
     "vkCreateComputePipelines" : {"dispatch": True, "driver" : False, "thunk" : ThunkType.PRIVATE},
+    "vkCreateFence" : {"dispatch": True, "driver" : False, "thunk" : ThunkType.NONE},
     "vkCreateGraphicsPipelines" : {"dispatch": True, "driver" : False, "thunk" : ThunkType.PRIVATE},
     "vkCreateImage" : {"dispatch" : True, "driver" : False, "thunk" : ThunkType.NONE},
     "vkCreateComputePipelines" : {"dispatch": True, "driver" : False, "thunk" : ThunkType.PRIVATE},
@@ -221,6 +222,7 @@ FUNCTION_OVERRIDES = {
     "vkCreateSemaphore" : {"dispatch" : True, "driver" : False, "thunk" : ThunkType.NONE},
     "vkDestroyCommandPool" : {"dispatch": True, "driver" : False, "thunk" : ThunkType.NONE},
     "vkDestroyDevice" : {"dispatch" : True, "driver" : False, "thunk" : ThunkType.NONE},
+    "vkDestroyFence" : {"dispatch" : True, "driver" : False, "thunk": ThunkType.NONE},
     "vkDestroySemaphore" : {"dispatch" : True, "driver" : False, "thunk" : ThunkType.NONE},
     "vkFreeCommandBuffers" : {"dispatch" : True, "driver" : False, "thunk" : ThunkType.NONE},
     "vkFreeMemory" : {"dispatch" : True, "driver" : False, "thunk" : ThunkType.NONE},
@@ -228,7 +230,9 @@ FUNCTION_OVERRIDES = {
     "vkGetDeviceQueue" : {"dispatch": True, "driver" : False, "thunk" : ThunkType.NONE},
     "vkGetDeviceQueue2" : {"dispatch": True, "driver" : False, "thunk" : ThunkType.NONE},
     "vkGetSemaphoreCounterValue" : {"dispatch": True, "driver": False, "thunk" : ThunkType.PRIVATE},
+    "vkResetFences" : {"dispatch" : True, "driver": False, "thunk" : ThunkType.PRIVATE},
     "vkSignalSemaphore" : {"dispatch": True, "driver": False, "thunk" : ThunkType.PRIVATE},
+    "vkWaitForFences" : {"dispatch": True, "driver": False, "thunk": ThunkType.PRIVATE},
     "vkWaitSemaphores" : {"dispatch": True, "driver": False, "thunk" : ThunkType.PRIVATE},
     "vkQueueBindSparse" : {"dispatch": True, "driver": False, "thunk" : ThunkType.PRIVATE},
     "vkQueueSubmit" : {"dispatch": True, "driver": False, "thunk" : ThunkType.PRIVATE},
@@ -1156,6 +1160,8 @@ class VkHandle(object):
             return "wine_dev_mem_from_handle({0})->dev_mem".format(name)
         if self.name == "VkSemaphore":
             return "wine_semaphore_from_handle({0})->semaphore".format(name)
+        if self.name == "VkFence":
+            return "wine_fence_from_handle({0})->fence".format(name)
 
         native_handle_name = None
 

--- a/dlls/winevulkan/make_vulkan
+++ b/dlls/winevulkan/make_vulkan
@@ -1533,7 +1533,7 @@ class VkMember(object):
 class VkParam(object):
     """ Helper class which describes a parameter to a function call. """
 
-    def __init__(self, type_info, const=None, pointer=None, name=None, array_len=None, dyn_array_len=None, object_type=None):
+    def __init__(self, type_info, const=None, pointer=None, name=None, array_len=None, dyn_array_len=None, object_type=None, optional=False):
         self.const = const
         self.name = name
         self.array_len = array_len
@@ -1541,6 +1541,7 @@ class VkParam(object):
         self.pointer = pointer
         self.object_type = object_type
         self.type_info = type_info
+        self.optional = optional
         self.type = type_info["name"] # For convenience
         self.handle = type_info["data"] if type_info["category"] == "handle" else None
         self.struct = type_info["data"] if type_info["category"] == "struct" else None
@@ -1580,12 +1581,14 @@ class VkParam(object):
         # Some uint64_t are actually handles with a separate type param
         object_type = param.get("objecttype", None)
 
+        optional = param.get("optional", False)
+
         # Since we have parsed all types before hand, this should not happen.
         type_info = types.get(type_elem.text, None)
         if type_info is None:
             LOGGER.err("type info not found for: {0}".format(type_elem.text))
 
-        return VkParam(type_info, const=const, pointer=pointer, name=name, array_len=array_len, dyn_array_len=dyn_array_len, object_type=object_type)
+        return VkParam(type_info, const=const, pointer=pointer, name=name, array_len=array_len, dyn_array_len=dyn_array_len, object_type=object_type, optional=optional)
 
     def _set_conversions(self):
         """ Internal helper function to configure any needed conversion functions. """
@@ -1922,7 +1925,10 @@ class VkParam(object):
             # the wine driver's handle to calls which are wrapped by the driver.
             p = "{0}{1}".format(params_prefix, self.name)
             driver_handle = self.handle.driver_handle(p) if self.is_handle() else None
-            return driver_handle if driver_handle else p
+            if driver_handle and self.optional:
+                return "{0} ? {1} : VK_NULL_HANDLE".format(p, driver_handle)
+            else:
+                return driver_handle if driver_handle else p
 
 
 class VkStruct(Sequence):

--- a/dlls/winevulkan/make_vulkan
+++ b/dlls/winevulkan/make_vulkan
@@ -98,7 +98,6 @@ UNSUPPORTED_EXTENSIONS = [
     "VK_EXT_hdr_metadata", # Needs WSI work.
     "VK_GOOGLE_display_timing",
     "VK_KHR_external_fence_win32",
-    "VK_KHR_external_semaphore_win32",
     # Relates to external_semaphore and needs type conversions in bitflags.
     "VK_KHR_shared_presentable_image", # Needs WSI work.
     "VK_KHR_win32_keyed_mutex",
@@ -111,7 +110,6 @@ UNSUPPORTED_EXTENSIONS = [
     "VK_EXT_physical_device_drm",
     "VK_GOOGLE_surfaceless_query",
     "VK_KHR_external_fence_fd",
-    "VK_KHR_external_semaphore_fd",
 
     # Extensions which require callback handling
     "VK_EXT_device_memory_report",
@@ -126,6 +124,7 @@ UNSUPPORTED_EXTENSIONS = [
 # but not expose to applications (useful for test commits)
 UNEXPOSED_EXTENSIONS = {
     "VK_KHR_external_memory_fd",
+    "VK_KHR_external_semaphore_fd",
 }
 
 # The Vulkan loader provides entry-points for core functionality and important
@@ -203,7 +202,7 @@ FUNCTION_OVERRIDES = {
     "vkEnumeratePhysicalDevices" : {"dispatch" : True, "driver" : False, "thunk" : ThunkType.NONE},
     "vkGetPhysicalDeviceExternalBufferProperties" : {"dispatch" : True, "driver" : False, "thunk" : ThunkType.NONE},
     "vkGetPhysicalDeviceExternalFenceProperties" : {"dispatch" : False, "driver" : False, "thunk" : ThunkType.NONE},
-    "vkGetPhysicalDeviceExternalSemaphoreProperties" : {"dispatch" : False, "driver" : False, "thunk" : ThunkType.NONE},
+    "vkGetPhysicalDeviceExternalSemaphoreProperties" : {"dispatch" : True, "driver" : False, "thunk" : ThunkType.NONE},
     "vkGetPhysicalDeviceImageFormatProperties2" : {"dispatch" : True, "driver" : False, "thunk" : ThunkType.PRIVATE},
     "vkGetPhysicalDeviceProperties" : {"dispatch" : True, "driver" : False, "thunk" : ThunkType.PUBLIC, "loader_thunk" : ThunkType.PRIVATE},
     "vkGetPhysicalDeviceProperties2" : {"dispatch" : True, "driver" : False, "thunk" : ThunkType.PUBLIC, "loader_thunk" : ThunkType.PRIVATE},
@@ -219,6 +218,7 @@ FUNCTION_OVERRIDES = {
     "vkCreateImage" : {"dispatch" : True, "driver" : False, "thunk" : ThunkType.NONE},
     "vkCreateComputePipelines" : {"dispatch": True, "driver" : False, "thunk" : ThunkType.PRIVATE},
     "vkCreateGraphicsPipelines" : {"dispatch": True, "driver" : False, "thunk" : ThunkType.PRIVATE},
+    "vkCreateSemaphore" : {"dispatch" : True, "driver" : False, "thunk" : ThunkType.NONE},
     "vkDestroyCommandPool" : {"dispatch": True, "driver" : False, "thunk" : ThunkType.NONE},
     "vkDestroyDevice" : {"dispatch" : True, "driver" : False, "thunk" : ThunkType.NONE},
     "vkFreeCommandBuffers" : {"dispatch" : True, "driver" : False, "thunk" : ThunkType.NONE},
@@ -258,7 +258,7 @@ FUNCTION_OVERRIDES = {
     "vkGetPhysicalDeviceImageFormatProperties2KHR" : {"dispatch" : True, "driver" : False, "thunk" : ThunkType.PRIVATE},
 
     # VK_KHR_external_semaphore_capabilities
-    "vkGetPhysicalDeviceExternalSemaphorePropertiesKHR" : {"dispatch" : False, "driver" : False, "thunk" : ThunkType.NONE},
+    "vkGetPhysicalDeviceExternalSemaphorePropertiesKHR" : {"dispatch" : True, "driver" : False, "thunk" : ThunkType.NONE},
 
     # VK_KHR_device_group_creation
     "vkEnumeratePhysicalDeviceGroupsKHR" : {"dispatch" : True, "driver" : False, "thunk" : ThunkType.NONE},
@@ -291,6 +291,10 @@ FUNCTION_OVERRIDES = {
 
     # VK_NV_ray_tracing
     "vkCreateRayTracingPipelinesNV" : {"dispatch": True, "driver" : False, "thunk" : ThunkType.PRIVATE},
+
+    # VK_KHR_external_semaphore_win32
+    "vkGetSemaphoreWin32HandleKHR" : {"dispatch" : True, "driver" : False, "thunk" : ThunkType.NONE},
+    "vkImportSemaphoreWin32HandleKHR" : {"dispatch" : True, "driver" : False, "thunk" : ThunkType.NONE},
 }
 
 STRUCT_CHAIN_CONVERSIONS = {
@@ -303,6 +307,8 @@ STRUCT_CHAIN_CONVERSIONS = {
     "VkImageCreateInfo": [],
     "VkMemoryAllocateInfo": ["VK_STRUCTURE_TYPE_EXPORT_MEMORY_WIN32_HANDLE_INFO_KHR", "VK_STRUCTURE_TYPE_IMPORT_MEMORY_WIN32_HANDLE_INFO_KHR"],
     "VkPhysicalDeviceImageFormatInfo2": [],
+    "VkSemaphoreCreateInfo": ["VK_STRUCTURE_TYPE_EXPORT_SEMAPHORE_WIN32_HANDLE_INFO_KHR"],
+    "VkD3D12FenceSubmitInfoKHR": ["VK_STRUCTURE_TYPE_D3D12_FENCE_SUBMIT_INFO_KHR"],
 }
 
 

--- a/dlls/winevulkan/make_vulkan
+++ b/dlls/winevulkan/make_vulkan
@@ -221,11 +221,18 @@ FUNCTION_OVERRIDES = {
     "vkCreateSemaphore" : {"dispatch" : True, "driver" : False, "thunk" : ThunkType.NONE},
     "vkDestroyCommandPool" : {"dispatch": True, "driver" : False, "thunk" : ThunkType.NONE},
     "vkDestroyDevice" : {"dispatch" : True, "driver" : False, "thunk" : ThunkType.NONE},
+    "vkDestroySemaphore" : {"dispatch" : True, "driver" : False, "thunk" : ThunkType.NONE},
     "vkFreeCommandBuffers" : {"dispatch" : True, "driver" : False, "thunk" : ThunkType.NONE},
     "vkFreeMemory" : {"dispatch" : True, "driver" : False, "thunk" : ThunkType.NONE},
     "vkGetDeviceProcAddr" : {"dispatch" : False, "driver" : True, "thunk" : ThunkType.NONE, "loader_thunk" : ThunkType.NONE},
     "vkGetDeviceQueue" : {"dispatch": True, "driver" : False, "thunk" : ThunkType.NONE},
     "vkGetDeviceQueue2" : {"dispatch": True, "driver" : False, "thunk" : ThunkType.NONE},
+    "vkGetSemaphoreCounterValue" : {"dispatch": True, "driver": False, "thunk" : ThunkType.PRIVATE},
+    "vkSignalSemaphore" : {"dispatch": True, "driver": False, "thunk" : ThunkType.PRIVATE},
+    "vkWaitSemaphores" : {"dispatch": True, "driver": False, "thunk" : ThunkType.PRIVATE},
+    "vkQueueBindSparse" : {"dispatch": True, "driver": False, "thunk" : ThunkType.PRIVATE},
+    "vkQueueSubmit" : {"dispatch": True, "driver": False, "thunk" : ThunkType.PRIVATE},
+    "vkQueueSubmit2" : {"dispatch": True, "driver": False, "thunk" : ThunkType.PRIVATE},
 
     # VK_KHR_surface
     "vkDestroySurfaceKHR" : {"dispatch" : True, "driver" : True, "thunk" : ThunkType.NONE},
@@ -248,7 +255,7 @@ FUNCTION_OVERRIDES = {
     "vkCreateSwapchainKHR" : {"dispatch" : True, "driver" : True, "thunk" : ThunkType.NONE},
     "vkDestroySwapchainKHR" : {"dispatch" : True, "driver" : True, "thunk" : ThunkType.NONE},
     "vkGetSwapchainImagesKHR": {"dispatch" : True, "driver" : True, "thunk" : ThunkType.NONE},
-    "vkQueuePresentKHR": {"dispatch" : True, "driver" : True, "thunk" : ThunkType.NONE},
+    "vkQueuePresentKHR": {"dispatch" : True, "driver" : True, "thunk" : ThunkType.PRIVATE},
 
     # VK_KHR_external_fence_capabilities
     "vkGetPhysicalDeviceExternalFencePropertiesKHR" : {"dispatch" : False, "driver" : False, "thunk" : ThunkType.NONE},
@@ -295,6 +302,14 @@ FUNCTION_OVERRIDES = {
     # VK_KHR_external_semaphore_win32
     "vkGetSemaphoreWin32HandleKHR" : {"dispatch" : True, "driver" : False, "thunk" : ThunkType.NONE},
     "vkImportSemaphoreWin32HandleKHR" : {"dispatch" : True, "driver" : False, "thunk" : ThunkType.NONE},
+
+    # VK_KHR_timeline_semaphore
+    "vkGetSemaphoreCounterValueKHR" : {"dispatch": True, "driver": False, "thunk" : ThunkType.PRIVATE},
+    "vkSignalSemaphoreKHR" : {"dispatch": True, "driver": False, "thunk" : ThunkType.PRIVATE},
+    "vkWaitSemaphoresKHR" : {"dispatch": True, "driver": False, "thunk" : ThunkType.PRIVATE},
+
+    # VK_KHR_synchronization2
+    "vkQueueSubmit2KHR" : {"dispatch": True, "driver": False, "thunk" : ThunkType.PRIVATE},
 }
 
 STRUCT_CHAIN_CONVERSIONS = {
@@ -307,8 +322,8 @@ STRUCT_CHAIN_CONVERSIONS = {
     "VkImageCreateInfo": [],
     "VkMemoryAllocateInfo": ["VK_STRUCTURE_TYPE_EXPORT_MEMORY_WIN32_HANDLE_INFO_KHR", "VK_STRUCTURE_TYPE_IMPORT_MEMORY_WIN32_HANDLE_INFO_KHR"],
     "VkPhysicalDeviceImageFormatInfo2": [],
+    "VkPhysicalDeviceExternalSemaphoreInfo": [],
     "VkSemaphoreCreateInfo": ["VK_STRUCTURE_TYPE_EXPORT_SEMAPHORE_WIN32_HANDLE_INFO_KHR"],
-    "VkD3D12FenceSubmitInfoKHR": ["VK_STRUCTURE_TYPE_D3D12_FENCE_SUBMIT_INFO_KHR"],
 }
 
 
@@ -1136,6 +1151,8 @@ class VkHandle(object):
             return "wine_surface_from_handle({0})->surface".format(name)
         if self.name == "VkDeviceMemory":
             return "wine_dev_mem_from_handle({0})->dev_mem".format(name)
+        if self.name == "VkSemaphore":
+            return "wine_semaphore_from_handle({0})->semaphore".format(name)
 
         native_handle_name = None
 
@@ -1788,9 +1805,6 @@ class VkParam(object):
         # 'parent' param requiring conversion.
         if self.is_struct():
             for m in self.struct:
-                if not m.is_struct():
-                    continue
-
                 if not m.needs_conversion() and not m.needs_unwrapping():
                     continue
 

--- a/dlls/winevulkan/make_vulkan
+++ b/dlls/winevulkan/make_vulkan
@@ -64,7 +64,7 @@ from enum import Enum
 LOGGER = logging.Logger("vulkan")
 LOGGER.addHandler(logging.StreamHandler())
 
-VK_XML_VERSION = "1.3.219"
+VK_XML_VERSION = "1.3.221"
 WINE_VK_VERSION = (1, 3)
 
 # Filenames to create.

--- a/dlls/winevulkan/make_vulkan
+++ b/dlls/winevulkan/make_vulkan
@@ -233,6 +233,7 @@ FUNCTION_OVERRIDES = {
     "vkQueueBindSparse" : {"dispatch": True, "driver": False, "thunk" : ThunkType.PRIVATE},
     "vkQueueSubmit" : {"dispatch": True, "driver": False, "thunk" : ThunkType.PRIVATE},
     "vkQueueSubmit2" : {"dispatch": True, "driver": False, "thunk" : ThunkType.PRIVATE},
+    "vkQueueWaitIdle" : {"dispatch": True, "driver": False, "thunk" : ThunkType.NONE},
 
     # VK_KHR_surface
     "vkDestroySurfaceKHR" : {"dispatch" : True, "driver" : True, "thunk" : ThunkType.NONE},

--- a/dlls/winevulkan/vk.xml
+++ b/dlls/winevulkan/vk.xml
@@ -159,7 +159,7 @@ branch of the member gitlab server.
         <type category="define" requires="VK_MAKE_API_VERSION">// Vulkan 1.3 version number
 #define <name>VK_API_VERSION_1_3</name> <type>VK_MAKE_API_VERSION</type>(0, 1, 3, 0)// Patch version should always be set to 0</type>
         <type category="define">// Version of this file
-#define <name>VK_HEADER_VERSION</name> 219</type>
+#define <name>VK_HEADER_VERSION</name> 221</type>
         <type category="define" requires="VK_HEADER_VERSION">// Complete version of this file
 #define <name>VK_HEADER_VERSION_COMPLETE</name> <type>VK_MAKE_API_VERSION</type>(0, 1, 3, VK_HEADER_VERSION)</type>
 
@@ -352,6 +352,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
         <type                                             category="bitmask" name="VkFormatFeatureFlags2KHR" alias="VkFormatFeatureFlags2"/>
         <type requires="VkRenderingFlagBits"              category="bitmask">typedef <type>VkFlags</type> <name>VkRenderingFlags</name>;</type>
         <type                                             category="bitmask" name="VkRenderingFlagsKHR" alias="VkRenderingFlags"/>
+
 
             <comment>WSI extensions</comment>
         <type requires="VkCompositeAlphaFlagBitsKHR"      category="bitmask">typedef <type>VkFlags</type> <name>VkCompositeAlphaFlagsKHR</name>;</type>
@@ -698,6 +699,8 @@ typedef void* <name>MTLSharedEvent_id</name>;
         <type name="VkImageCompressionFlagBitsEXT" category="enum"/>
         <type name="VkImageCompressionFixedRateFlagBitsEXT" category="enum"/>
         <type name="VkExportMetalObjectTypeFlagBitsEXT" category="enum"/>
+        <type name="VkPipelineRobustnessBufferBehaviorEXT" category="enum"/>
+        <type name="VkPipelineRobustnessImageBehaviorEXT" category="enum"/>
 
             <comment>WSI extensions</comment>
         <type name="VkColorSpaceKHR" category="enum"/>
@@ -1254,7 +1257,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
         </type>
         <type category="struct" name="VkShaderModuleCreateInfo" structextends="VkPipelineShaderStageCreateInfo">
             <member values="VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO"><type>VkStructureType</type> <name>sType</name></member>
-            <member optional="true">const <type>void</type>*            <name>pNext</name></member>
+            <member noautovalidity="true" optional="true">const <type>void</type>*            <name>pNext</name><comment>noautovalidity because this structure can be either an explicit parameter, or passed in a pNext chain</comment></member>
             <member optional="true"><type>VkShaderModuleCreateFlags</type> <name>flags</name></member>
             <member><type>size_t</type>                 <name>codeSize</name><comment>Specified in bytes</comment></member>
             <member len="latexmath:[\textrm{codeSize} \over 4]" altlen="codeSize / 4">const <type>uint32_t</type>*            <name>pCode</name><comment>Binary code of size codeSize</comment></member>
@@ -3352,7 +3355,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <member optional="true"><type>size_t</type>                 <name>initialDataSize</name></member>
             <member len="initialDataSize">const <type>void</type>*            <name>pInitialData</name></member>
         </type>
-        <type category="struct" name="VkShaderModuleValidationCacheCreateInfoEXT" structextends="VkShaderModuleCreateInfo">
+        <type category="struct" name="VkShaderModuleValidationCacheCreateInfoEXT" structextends="VkShaderModuleCreateInfo,VkPipelineShaderStageCreateInfo">
             <member values="VK_STRUCTURE_TYPE_SHADER_MODULE_VALIDATION_CACHE_CREATE_INFO_EXT"><type>VkStructureType</type> <name>sType</name></member>
             <member optional="true">const <type>void</type>*            <name>pNext</name></member>
             <member><type>VkValidationCacheEXT</type>    <name>validationCache</name></member>
@@ -7031,6 +7034,27 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <member optional="true" noautovalidity="true"><type>void</type>*                                                   <name>pNext</name></member>
             <member><type>VkBool32</type>                                                                                      <name>nonSeamlessCubeMap</name></member>
         </type>
+        <type category="struct" name="VkPhysicalDevicePipelineRobustnessFeaturesEXT" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
+            <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PIPELINE_ROBUSTNESS_FEATURES_EXT"><type>VkStructureType</type> <name>sType</name></member>
+            <member noautovalidity="true" optional="true"><type>void</type>*    <name>pNext</name></member>
+            <member><type>VkBool32</type>                                       <name>pipelineRobustness</name></member>
+        </type>
+        <type category="struct" name="VkPipelineRobustnessCreateInfoEXT" structextends="VkGraphicsPipelineCreateInfo,VkComputePipelineCreateInfo,VkPipelineShaderStageCreateInfo,VkRayTracingPipelineCreateInfoKHR">
+            <member values="VK_STRUCTURE_TYPE_PIPELINE_ROBUSTNESS_CREATE_INFO_EXT"><type>VkStructureType</type> <name>sType</name></member>
+            <member noautovalidity="true" optional="true">const <type>void</type>*      <name>pNext</name></member>
+            <member><type>VkPipelineRobustnessBufferBehaviorEXT</type>   <name>storageBuffers</name></member>
+            <member><type>VkPipelineRobustnessBufferBehaviorEXT</type>   <name>uniformBuffers</name></member>
+            <member><type>VkPipelineRobustnessBufferBehaviorEXT</type>   <name>vertexInputs</name></member>
+            <member><type>VkPipelineRobustnessImageBehaviorEXT</type>    <name>images</name></member>
+        </type>
+        <type category="struct" name="VkPhysicalDevicePipelineRobustnessPropertiesEXT" returnedonly="true" structextends="VkPhysicalDeviceProperties2">
+        	<member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PIPELINE_ROBUSTNESS_PROPERTIES_EXT"><type>VkStructureType</type> <name>sType</name></member>
+            <member optional="true"><type>void</type>* <name>pNext</name></member>
+            <member limittype="noauto"><type>VkPipelineRobustnessBufferBehaviorEXT</type>   <name>defaultRobustnessStorageBuffers</name></member>
+            <member limittype="noauto"><type>VkPipelineRobustnessBufferBehaviorEXT</type>   <name>defaultRobustnessUniformBuffers</name></member>
+            <member limittype="noauto"><type>VkPipelineRobustnessBufferBehaviorEXT</type>   <name>defaultRobustnessVertexInputs</name></member>
+            <member limittype="noauto"><type>VkPipelineRobustnessImageBehaviorEXT</type>    <name>defaultRobustnessImages</name></member>
+        </type>
     </types>
     <comment>Vulkan enumerant (token) definitions</comment>
 
@@ -7919,8 +7943,10 @@ typedef void* <name>MTLSharedEvent_id</name>;
         <enum               name="VK_DEBUG_REPORT_OBJECT_TYPE_DEBUG_REPORT_EXT" alias="VK_DEBUG_REPORT_OBJECT_TYPE_DEBUG_REPORT_CALLBACK_EXT_EXT" comment="Backwards-compatible alias containing a typo"/>
         <enum value="29"    name="VK_DEBUG_REPORT_OBJECT_TYPE_DISPLAY_KHR_EXT"/>
         <enum value="30"    name="VK_DEBUG_REPORT_OBJECT_TYPE_DISPLAY_MODE_KHR_EXT"/>
-        <!--<enum value="31"    name="VK_DEBUG_REPORT_OBJECT_TYPE_OBJECT_TABLE_NVX_EXT" comment="Removed NVX_device_generated_commands"/>-->
-        <!--<enum value="32"    name="VK_DEBUG_REPORT_OBJECT_TYPE_INDIRECT_COMMANDS_LAYOUT_NVX_EXT" comment="Removed NVX_device_generated_commands"/>-->
+            <comment>NVX_device_generated_commands formerly used these enum values, but that extension has been removed
+                value 31 / name VK_DEBUG_REPORT_OBJECT_TYPE_OBJECT_TABLE_NVX_EXT
+                value 32 / name VK_DEBUG_REPORT_OBJECT_TYPE_INDIRECT_COMMANDS_LAYOUT_NVX_EXT
+            </comment>
         <enum value="33"    name="VK_DEBUG_REPORT_OBJECT_TYPE_VALIDATION_CACHE_EXT_EXT"/>
         <enum               name="VK_DEBUG_REPORT_OBJECT_TYPE_VALIDATION_CACHE_EXT" alias="VK_DEBUG_REPORT_OBJECT_TYPE_VALIDATION_CACHE_EXT_EXT" comment="Backwards-compatible alias containing a typo"/>
     </enums>
@@ -8525,7 +8551,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
         <enum               name="VK_ACCESS_2_MEMORY_READ_BIT_KHR" alias="VK_ACCESS_2_MEMORY_READ_BIT"/>
         <enum bitpos="16"   name="VK_ACCESS_2_MEMORY_WRITE_BIT"/>
         <enum               name="VK_ACCESS_2_MEMORY_WRITE_BIT_KHR" alias="VK_ACCESS_2_MEMORY_WRITE_BIT"/>
-        <!-- bitpos 17-31 are specified by extensions to the original VkAccessFlagBits enum -->
+            <comment>bitpos 17-31 are specified by extensions to the original VkAccessFlagBits enum</comment>
         <enum bitpos="32"   name="VK_ACCESS_2_SHADER_SAMPLED_READ_BIT"/>
         <enum               name="VK_ACCESS_2_SHADER_SAMPLED_READ_BIT_KHR" alias="VK_ACCESS_2_SHADER_SAMPLED_READ_BIT"/>
         <enum bitpos="33"   name="VK_ACCESS_2_SHADER_STORAGE_READ_BIT"/>
@@ -8572,7 +8598,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
         <enum               name="VK_PIPELINE_STAGE_2_ALL_GRAPHICS_BIT_KHR" alias="VK_PIPELINE_STAGE_2_ALL_GRAPHICS_BIT"/>
         <enum bitpos="16"   name="VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT"/>
         <enum               name="VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT_KHR" alias="VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT"/>
-        <!-- bitpos 17-31 are specified by extensions to the original VkPipelineStageFlagBits enum -->
+            <comment>bitpos 17-31 are specified by extensions to the original VkPipelineStageFlagBits enum</comment>
         <enum bitpos="32"   name="VK_PIPELINE_STAGE_2_COPY_BIT"/>
         <enum               name="VK_PIPELINE_STAGE_2_COPY_BIT_KHR" alias="VK_PIPELINE_STAGE_2_COPY_BIT"/>
         <enum bitpos="33"   name="VK_PIPELINE_STAGE_2_RESOLVE_BIT"/>
@@ -8897,7 +8923,18 @@ typedef void* <name>MTLSharedEvent_id</name>;
         <enum bitpos="22"    name="VK_IMAGE_COMPRESSION_FIXED_RATE_23BPC_BIT_EXT"/>
         <enum bitpos="23"    name="VK_IMAGE_COMPRESSION_FIXED_RATE_24BPC_BIT_EXT"/>
     </enums>
-
+    <enums name="VkPipelineRobustnessBufferBehaviorEXT" type="enum">
+    	<enum value="0"		name="VK_PIPELINE_ROBUSTNESS_BUFFER_BEHAVIOR_DEVICE_DEFAULT_EXT" />
+    	<enum value="1"		name="VK_PIPELINE_ROBUSTNESS_BUFFER_BEHAVIOR_DISABLED_EXT" />
+        <enum value="2"    	name="VK_PIPELINE_ROBUSTNESS_BUFFER_BEHAVIOR_ROBUST_BUFFER_ACCESS_EXT" />
+        <enum value="3"    	name="VK_PIPELINE_ROBUSTNESS_BUFFER_BEHAVIOR_ROBUST_BUFFER_ACCESS_2_EXT" />
+    </enums>
+    <enums name="VkPipelineRobustnessImageBehaviorEXT" type="enum">
+    	<enum value="0"		name="VK_PIPELINE_ROBUSTNESS_IMAGE_BEHAVIOR_DEVICE_DEFAULT_EXT" />
+    	<enum value="1"		name="VK_PIPELINE_ROBUSTNESS_IMAGE_BEHAVIOR_DISABLED_EXT" />
+        <enum value="2"    	name="VK_PIPELINE_ROBUSTNESS_IMAGE_BEHAVIOR_ROBUST_IMAGE_ACCESS_EXT" />
+        <enum value="3"    	name="VK_PIPELINE_ROBUSTNESS_IMAGE_BEHAVIOR_ROBUST_IMAGE_ACCESS_2_EXT" />
+    </enums>
     <commands comment="Vulkan command definitions">
         <command successcodes="VK_SUCCESS" errorcodes="VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_INITIALIZATION_FAILED,VK_ERROR_LAYER_NOT_PRESENT,VK_ERROR_EXTENSION_NOT_PRESENT,VK_ERROR_INCOMPATIBLE_DRIVER">
             <proto><type>VkResult</type> <name>vkCreateInstance</name></proto>
@@ -13325,7 +13362,6 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <enum offset="12" extends="VkFormat" extnumber="67"                 name="VK_FORMAT_ASTC_12x10_SFLOAT_BLOCK"/>
             <enum offset="13" extends="VkFormat" extnumber="67"                 name="VK_FORMAT_ASTC_12x12_SFLOAT_BLOCK"/>
         </require>
-            <!-- Beginning of phase II extensions -->
         <require comment="Promoted from VK_KHR_dynamic_rendering (extension 45)">
             <command name="vkCmdBeginRendering"/>
             <command name="vkCmdEndRendering"/>
@@ -13650,8 +13686,8 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <require>
                 <enum value="1"                                                 name="VK_IMG_FILTER_CUBIC_SPEC_VERSION"/>
                 <enum value="&quot;VK_IMG_filter_cubic&quot;"                   name="VK_IMG_FILTER_CUBIC_EXTENSION_NAME"/>
-                <enum offset="0" extends="VkFilter"                             name="VK_FILTER_CUBIC_IMG"/>
-                <enum bitpos="13" extends="VkFormatFeatureFlagBits"             name="VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_CUBIC_BIT_IMG" comment="Format can be filtered with VK_FILTER_CUBIC_IMG when being sampled"/>
+                <enum extends="VkFilter"                                        name="VK_FILTER_CUBIC_IMG" alias="VK_FILTER_CUBIC_EXT"/>
+                <enum extends="VkFormatFeatureFlagBits"                         name="VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_CUBIC_BIT_IMG" alias="VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_CUBIC_BIT_EXT" comment="Format can be filtered with VK_FILTER_CUBIC_IMG when being sampled"/>
             </require>
         </extension>
         <extension name="VK_AMD_extension_17" number="17" author="AMD" contact="Daniel Rakos @drakos-amd" supported="disabled">
@@ -14436,10 +14472,18 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <type name="VkPhysicalDeviceASTCDecodeFeaturesEXT"/>
             </require>
         </extension>
-        <extension name="VK_IMG_extension_69" number="69" type="device" author="IMG" contact="Tobias Hector @tobski" supported="disabled">
+        <extension name="VK_EXT_pipeline_robustness" requires="VK_KHR_get_physical_device_properties2" number="69" type="device" author="IMG" contact="Jarred Davies" supported="vulkan">
             <require>
-                <enum value="0"                                                 name="VK_IMG_EXTENSION_69_SPEC_VERSION"/>
-                <enum value="&quot;VK_IMG_extension_69&quot;"                   name="VK_IMG_EXTENSION_69_EXTENSION_NAME"/>
+                <enum value="1"                                                 name="VK_EXT_PIPELINE_ROBUSTNESS_SPEC_VERSION"/>
+                <enum value="&quot;VK_EXT_pipeline_robustness&quot;"            name="VK_EXT_PIPELINE_ROBUSTNESS_EXTENSION_NAME"/>
+                <enum offset="0" extends="VkStructureType"                      name="VK_STRUCTURE_TYPE_PIPELINE_ROBUSTNESS_CREATE_INFO_EXT"/>
+                <enum offset="1" extends="VkStructureType"                      name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PIPELINE_ROBUSTNESS_FEATURES_EXT"/>
+                <enum offset="2" extends="VkStructureType"                      name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PIPELINE_ROBUSTNESS_PROPERTIES_EXT"/>
+                <type name="VkPhysicalDevicePipelineRobustnessFeaturesEXT"/>
+                <type name="VkPhysicalDevicePipelineRobustnessPropertiesEXT"/>
+                <type name="VkPipelineRobustnessCreateInfoEXT"/>
+                <type name="VkPipelineRobustnessBufferBehaviorEXT"/>
+                <type name="VkPipelineRobustnessImageBehaviorEXT"/>
             </require>
         </extension>
         <extension name="VK_KHR_maintenance1" number="70" type="device" author="KHR" contact="Piers Daniell @pdaniell-nv" supported="vulkan" promotedto="VK_VERSION_1_1">
@@ -15428,7 +15472,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <type name="VkImageFormatListCreateInfoKHR"/>
             </require>
         </extension>
-        <extension name="VK_EXT_blend_operation_advanced" number="149" type="device" author="NV" contact="Jeff Bolz @jeffbolznv" supported="vulkan">
+        <extension name="VK_EXT_blend_operation_advanced" number="149" type="device" author="NV" contact="Jeff Bolz @jeffbolznv" supported="vulkan" requires="VK_KHR_get_physical_device_properties2">
             <require>
                 <enum value="2"                                             name="VK_EXT_BLEND_OPERATION_ADVANCED_SPEC_VERSION"/>
                 <enum value="&quot;VK_EXT_blend_operation_advanced&quot;"   name="VK_EXT_BLEND_OPERATION_ADVANCED_EXTENSION_NAME"/>
@@ -16033,8 +16077,8 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <require>
                 <enum value="3"                                             name="VK_EXT_FILTER_CUBIC_SPEC_VERSION"/>
                 <enum value="&quot;VK_EXT_filter_cubic&quot;"               name="VK_EXT_FILTER_CUBIC_EXTENSION_NAME"/>
-                <enum extends="VkFilter"                                    name="VK_FILTER_CUBIC_EXT" alias="VK_FILTER_CUBIC_IMG"/>
-                <enum extends="VkFormatFeatureFlagBits"                     name="VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_CUBIC_BIT_EXT" alias="VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_CUBIC_BIT_IMG"/>
+                <enum offset="0" extends="VkFilter" extnumber="16"          name="VK_FILTER_CUBIC_EXT"/>
+                <enum bitpos="13" extends="VkFormatFeatureFlagBits"         name="VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_CUBIC_BIT_EXT"/>
                 <enum offset="0" extends="VkStructureType"                  name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGE_VIEW_IMAGE_FORMAT_INFO_EXT"/>
                 <enum offset="1" extends="VkStructureType"                  name="VK_STRUCTURE_TYPE_FILTER_CUBIC_IMAGE_VIEW_IMAGE_FORMAT_PROPERTIES_EXT"/>
                 <type name="VkPhysicalDeviceImageViewImageFormatInfoEXT"/>
@@ -17732,6 +17776,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum value="0"                                             name="VK_AMD_EXTENSION_317_SPEC_VERSION"/>
                 <enum value="&quot;VK_AMD_extension_317&quot;"              name="VK_AMD_EXTENSION_317_EXTENSION_NAME"/>
                 <enum bitpos="4" extends="VkDescriptorSetLayoutCreateFlagBits"  name="VK_DESCRIPTOR_SET_LAYOUT_CREATE_RESERVED_4_BIT_AMD"/>
+                <enum bitpos="5" extends="VkDescriptorSetLayoutCreateFlagBits"  name="VK_DESCRIPTOR_SET_LAYOUT_CREATE_RESERVED_5_BIT_AMD"/>
                 <enum bitpos="21" extends="VkBufferUsageFlagBits"               name="VK_BUFFER_USAGE_RESERVED_21_BIT_AMD"/>
                 <enum bitpos="22" extends="VkBufferUsageFlagBits"               name="VK_BUFFER_USAGE_RESERVED_22_BIT_AMD"/>
                 <enum bitpos="5" extends="VkBufferCreateFlagBits"               name="VK_BUFFER_CREATE_RESERVED_5_BIT_AMD"/>
@@ -17739,6 +17784,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
                 <enum bitpos="3" extends="VkSamplerCreateFlagBits"              name="VK_SAMPLER_CREATE_RESERVED_3_BIT_AMD"/>
                 <enum bitpos="41" extends="VkAccessFlagBits2"                   name="VK_ACCESS_2_RESERVED_41_BIT_AMD"/>
                 <enum bitpos="2" extends="VkImageViewCreateFlagBits"            name="VK_IMAGE_VIEW_CREATE_RESERVED_2_BIT_AMD"/>
+                <enum bitpos="3" extends="VkAccelerationStructureCreateFlagBitsKHR" name="VK_ACCELERATION_STRUCTURE_CREATE_RESERVED_3_BIT_AMD"/>
             </require>
         </extension>
         <extension name="VK_AMD_extension_318" number="318" author="AMD" contact="Martin Dinkov @mdinkov" supported="disabled">
@@ -19163,6 +19209,12 @@ typedef void* <name>MTLSharedEvent_id</name>;
             <require>
                 <enum value="0"                                         name="VK_EXT_EXTENSION_484_SPEC_VERSION"/>
                 <enum value="&quot;VK_EXT_extension_484&quot;"          name="VK_EXT_EXTENSION_484_EXTENSION_NAME"/>
+            </require>
+        </extension>
+        <extension name="VK_QCOM_extension_485" number="485" author="QCOM" contact="Jeff Leger @jackohound" supported="disabled">
+            <require>
+                <enum value="0"                                         name="VK_QCOM_EXTENSION_485_SPEC_VERSION"/>
+                <enum value="&quot;VK_QCOM_extension_485&quot;"         name="VK_QCOM_EXTENSION_485_EXTENSION_NAME"/>
             </require>
         </extension>
     </extensions>
@@ -21102,6 +21154,7 @@ typedef void* <name>MTLSharedEvent_id</name>;
         </spirvcapability>
         <spirvcapability name="RayTraversalPrimitiveCullingKHR">
             <enable struct="VkPhysicalDeviceRayTracingPipelineFeaturesKHR" feature="rayTraversalPrimitiveCulling" requires="VK_KHR_ray_tracing_pipeline"/>
+            <enable struct="VkPhysicalDeviceRayQueryFeaturesKHR" feature="rayQuery" requires="VK_KHR_ray_query"/>
         </spirvcapability>
         <spirvcapability name="RayCullMaskKHR">
              <enable struct="VkPhysicalDeviceRayTracingMaintenance1FeaturesKHR" feature="rayTracingMaintenance1" requires="VK_KHR_ray_tracing_maintenance1"/>

--- a/dlls/winevulkan/vulkan.c
+++ b/dlls/winevulkan/vulkan.c
@@ -27,6 +27,8 @@
 #include <stdlib.h>
 #include <unistd.h>
 #include <stdbool.h>
+#include <stdio.h>
+#include <assert.h>
 
 #include "ntstatus.h"
 #define WIN32_NO_STATUS
@@ -4197,6 +4199,73 @@ static void d3d12_semaphore_unlock(struct wine_semaphore *semaphore)
     pthread_mutex_unlock(&semaphore->d3d12_fence_shm->mutex);
 }
 
+/* returns -1 when there is no queued update that would satisfy the wait */
+static uint64_t d3d12_semaphore_try_get_wait_value_locked(struct wine_semaphore *semaphore, uint64_t virtual_value,
+        struct VkQueue_T *waiting_queue)
+{
+    struct pending_update *update;
+    uint64_t ret = -1;
+    unsigned int i;
+
+    if (semaphore->d3d12_fence_shm->virtual_value >= virtual_value)
+        return 0;
+
+    return ret;
+}
+
+static struct pending_wait *d3d12_semaphore_push_wait_locked(struct wine_semaphore *semaphore, uint64_t virtual_value)
+{
+    struct pending_wait *wait;
+    unsigned int i;
+
+    for (i = 0; i < ARRAY_SIZE(semaphore->d3d12_fence_shm->pending_waits); i++)
+    {
+        wait = &semaphore->d3d12_fence_shm->pending_waits[i];
+        if (!wait->present)
+            break;
+    }
+
+    if (i == ARRAY_SIZE(semaphore->d3d12_fence_shm->pending_waits))
+    {
+        FIXME("Failed to wait on semaphore %p, maximum waits exceeded.\n", semaphore);
+        return NULL;
+    }
+
+    wait->present = true;
+    wait->satisfied = false;
+    wait->virtual_value = virtual_value;
+    wait->physical_value = 0;
+
+    return wait;
+}
+
+static uint64_t d3d12_semaphore_pop_wait_locked(struct wine_semaphore *semaphore, struct pending_wait *wait)
+{
+    wait->satisfied = false;
+    wait->present = false;
+
+    return wait->physical_value;
+}
+
+static void d3d12_semaphore_satisfy_waits_locked(struct wine_semaphore *semaphore, uint64_t virtual_value,
+        uint64_t physical_value)
+{
+    struct pending_wait *wait;
+    unsigned int i;
+
+    for (i = 0; i < ARRAY_SIZE(semaphore->d3d12_fence_shm->pending_waits); i++)
+    {
+        wait = &semaphore->d3d12_fence_shm->pending_waits[i];
+
+        if (wait->present && !wait->satisfied && wait->virtual_value <= virtual_value)
+        {
+            wait->satisfied = true;
+            wait->physical_value = physical_value;
+            pthread_cond_signal(&wait->cond);
+        }
+    }
+}
+
 NTSTATUS wine_vkCreateSemaphore(void *args)
 {
     struct vkCreateSemaphore_params *params = args;
@@ -4215,6 +4284,7 @@ NTSTATUS wine_vkCreateSemaphore(void *args)
     OBJECT_ATTRIBUTES attr;
     HANDLE section_handle;
     LARGE_INTEGER li;
+    unsigned int i;
     VkResult res;
     SIZE_T size;
     int fd;
@@ -4308,6 +4378,14 @@ NTSTATUS wine_vkCreateSemaphore(void *args)
                     goto done;
                 }
                 pthread_mutexattr_destroy(&mutex_attr);
+
+                for (i = 0; i < ARRAY_SIZE(object->d3d12_fence_shm->pending_waits); i++)
+                {
+                    pthread_condattr_init(&cond_attr);
+                    pthread_condattr_setpshared(&cond_attr, PTHREAD_PROCESS_SHARED);
+                    pthread_cond_init(&object->d3d12_fence_shm->pending_waits[i].cond, &cond_attr);
+                    pthread_condattr_destroy(&cond_attr);
+                }
             }
         }
 
@@ -4526,14 +4604,40 @@ NTSTATUS wine_vkGetSemaphoreCounterValueKHR(void *args)
 static NTSTATUS vk_signal_semaphore(VkDevice device, const VkSemaphoreSignalInfo *signal_info, bool khr);
 static NTSTATUS wine_vk_signal_semaphore(VkDevice device, const VkSemaphoreSignalInfo *signal_info, bool khr)
 {
+    VkResult vr;
+
     struct wine_semaphore *semaphore = wine_semaphore_from_handle(signal_info->semaphore);
 
     TRACE("(%p, %p)\n", device, signal_info);
 
     if (semaphore->handle_types & VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_D3D12_FENCE_BIT)
     {
-        FIXME("Signalling D3D12-Fence compatible timeline semaphore not supported.\n");
-        return VK_ERROR_OUT_OF_HOST_MEMORY;
+        VkSemaphoreSignalInfo step_signal_info;
+
+        d3d12_semaphore_lock(semaphore);
+
+        assert(semaphore->d3d12_fence_shm->counter == phys_val);
+        phys_val++;
+
+        semaphore->d3d12_fence_shm->counter = semaphore->d3d12_fence_shm->physical_value = phys_val;
+
+        step_signal_info.sType = VK_STRUCTURE_TYPE_SEMAPHORE_SIGNAL_INFO;
+        step_signal_info.pNext = NULL;
+        step_signal_info.semaphore = signal_info->semaphore;
+        step_signal_info.value = phys_val;
+
+        vr = vk_signal_semaphore(device, &step_signal_info, khr);
+        if (vr != VK_SUCCESS)
+        {
+            d3d12_semaphore_unlock(semaphore);
+            return vr;
+        }
+
+        d3d12_semaphore_satisfy_waits_locked(semaphore, signal_info->value, 0);
+        semaphore->d3d12_fence_shm->virtual_value = signal_info->value;
+
+        d3d12_semaphore_unlock(semaphore);
+        return VK_SUCCESS;
     }
 
     return vk_signal_semaphore(device, signal_info, khr);
@@ -4568,22 +4672,144 @@ NTSTATUS wine_vkSignalSemaphoreKHR(void *args)
 static NTSTATUS vk_wait_semaphores(VkDevice device, const VkSemaphoreWaitInfo *wait_info, uint64_t timeout, bool khr);
 static NTSTATUS wine_vk_wait_semaphores(VkDevice device, const VkSemaphoreWaitInfo *wait_info, uint64_t timeout, bool khr)
 {
-    unsigned int i;
+    VkSemaphoreWaitInfo wait_info_dup = *wait_info;
+    struct timespec abs_timeout, start_time;
+    struct pending_wait **pending_waits;
+    struct pending_wait *pending_wait;
+    unsigned int i, remaining_waits;
+    VkSemaphore* semaphores_dup;
+    uint64_t *values_dup;
+    uint64_t phys_val;
+    int wait_stat;
+    VkResult res;
 
     TRACE("(%p, %p, 0x%s)\n", device, wait_info, wine_dbgstr_longlong(timeout));
+
+    if (timeout)
+    {
+        clock_gettime(CLOCK_REALTIME, &start_time);
+
+        abs_timeout.tv_sec = start_time.tv_sec + (timeout / NANOSECONDS_IN_A_SECOND);
+        abs_timeout.tv_nsec = start_time.tv_nsec + (timeout % NANOSECONDS_IN_A_SECOND);
+        if (abs_timeout.tv_nsec >= NANOSECONDS_IN_A_SECOND)
+        {
+            abs_timeout.tv_sec++;
+            abs_timeout.tv_nsec-=NANOSECONDS_IN_A_SECOND;
+        }
+    }
+
+    wait_info_dup.pSemaphores = semaphores_dup = calloc(wait_info->semaphoreCount, sizeof(VkSemaphore));
+    wait_info_dup.pValues = values_dup = calloc(wait_info->semaphoreCount, sizeof(uint64_t));
+    pending_waits = calloc(wait_info->semaphoreCount, sizeof(struct pending_wait *));
 
     for (i = 0; i < wait_info->semaphoreCount; i++)
     {
         struct wine_semaphore *semaphore = wine_semaphore_from_handle(wait_info->pSemaphores[i]);
 
+        semaphores_dup[i] = wait_info->pSemaphores[i];
+        values_dup[i] = wait_info->pValues[i];
+
         if (semaphore->handle_types & VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_D3D12_FENCE_BIT)
         {
-            FIXME("Waiting on D3D12-Fence compatible timeline semaphores not supported.");
-            return return VK_ERROR_OUT_OF_HOST_MEMORY;
+            d3d12_semaphore_lock(semaphore);
+            if ((values_dup[i] = d3d12_semaphore_try_get_wait_value_locked(semaphore, wait_info->pValues[i], NULL)) == -1)
+            {
+                if (!timeout)
+                {
+                    d3d12_semaphore_unlock(semaphore);
+                    continue;
+                }
+
+                pending_wait = d3d12_semaphore_push_wait_locked(semaphore, wait_info->pValues[i]);
+
+                if (wait_info->flags & VK_SEMAPHORE_WAIT_ANY_BIT)
+                {
+                    /* Keep scheduling a wait of current physical_value+1 until the desired virtual value is signaled */
+                    values_dup[i] = semaphore->d3d12_fence_shm->physical_value + 1;
+                    pending_waits[i] = pending_wait;
+                }
+                else
+                {
+                    while (!pending_wait->satisfied && wait_stat != ETIMEDOUT)
+                        wait_stat = pthread_cond_timedwait(&pending_wait->cond, &semaphore->d3d12_fence_shm->mutex, &abs_timeout);
+
+                    values_dup[i] = d3d12_semaphore_pop_wait_locked(semaphore, pending_wait);
+
+                    if (wait_stat == ETIMEDOUT)
+                    {
+                        d3d12_semaphore_unlock(semaphore);
+                        free(semaphores_dup);
+                        free(values_dup);
+                        free(pending_waits);
+                        return VK_TIMEOUT;
+                    }
+                }
+            }
+            d3d12_semaphore_unlock(semaphore);
         }
     }
 
-    return vk_wait_semaphores(device, wait_info, timeout, khr);
+    do
+    {
+        if (timeout)
+        {
+            clock_gettime(CLOCK_REALTIME, &start_time);
+
+            if (start_time.tv_sec > abs_timeout.tv_sec ||
+                    (start_time.tv_sec == abs_timeout.tv_sec && start_time.tv_nsec >= abs_timeout.tv_nsec))
+                timeout = 0;
+            else
+                timeout = ((abs_timeout.tv_sec - start_time.tv_sec) * NANOSECONDS_IN_A_SECOND) +
+                    (abs_timeout.tv_nsec - start_time.tv_nsec);
+        }
+
+        remaining_waits = 0;
+        res = vk_wait_semaphores(device, &wait_info_dup, timeout, khr);
+
+        for (i = 0; i < wait_info->semaphoreCount; i++)
+        {
+            struct wine_semaphore * semaphore = wine_semaphore_from_handle(wait_info->pSemaphores[i]);
+
+            if (pending_waits[i])
+            {
+                remaining_waits++;
+
+                d3d12_semaphore_lock(semaphore);
+                if (res != VK_SUCCESS || pending_waits[i]->satisfied)
+                {
+                    values_dup[i] = pending_waits[i]->physical_value;
+                    d3d12_semaphore_pop_wait_locked(semaphore, pending_waits[i]);
+                    pending_waits[i] = NULL;
+                }
+                d3d12_semaphore_unlock(semaphore);
+            }
+        }
+    }
+    while (res == VK_SUCCESS && remaining_waits);
+
+    /* Make sure the physical value we waited on is processed before returning */
+    for (i = 0; i < wait_info_dup.semaphoreCount; i++)
+    {
+        struct wine_semaphore *semaphore = wine_semaphore_from_handle(wait_info_dup.pSemaphores[i]);
+
+        if (semaphore->handle_types & VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_D3D12_FENCE_BIT)
+        {
+            d3d12_semaphore_lock(semaphore);
+            if (wait_info->flags & VK_SEMAPHORE_WAIT_ANY_BIT)
+            {
+                if (!vk_get_semaphore_counter_value(device, semaphores_dup[i], &phys_val, khr))
+                    d3d12_semaphore_update_phys_val_locked(semaphore, phys_val);
+            }
+            else
+                d3d12_semaphore_update_phys_val_locked(semaphore, values_dup[i]);
+            d3d12_semaphore_unlock(semaphore);
+        }
+    }
+
+    free(semaphores_dup);
+    free(values_dup);
+    free(pending_waits);
+    return res;
 }
 
 static NTSTATUS vk_wait_semaphores(VkDevice device, const VkSemaphoreWaitInfo *wait_info, uint64_t timeout, bool khr)

--- a/dlls/winevulkan/vulkan.c
+++ b/dlls/winevulkan/vulkan.c
@@ -29,6 +29,9 @@
 #include <stdbool.h>
 #include <stdio.h>
 #include <assert.h>
+#include <errno.h>
+#include <poll.h>
+#include <sys/eventfd.h>
 
 #include "ntstatus.h"
 #define WIN32_NO_STATUS
@@ -4980,6 +4983,7 @@ struct signal_op
     enum
     {
         SIGNAL_TYPE_SEMAPHORE,
+        SIGNAL_TYPE_FENCE,
     } signal_type;
 
     union
@@ -4991,6 +4995,8 @@ struct signal_op
 
             bool khr;
         } semaphore;
+
+        struct wine_fence *fence;
     };
 
     struct list entry;
@@ -5003,6 +5009,8 @@ static void *queue_signaller_worker(void *arg)
     struct signal_op *signal_op;
     VkSemaphore sem_handle;
     bool device_lost;
+    VkFence fence;
+    uint64_t buf;
     VkResult vr;
 
     for (;;)
@@ -5045,6 +5053,20 @@ static void *queue_signaller_worker(void *arg)
             d3d12_semaphore_lock(signal_op->semaphore.obj);
             d3d12_semaphore_update_phys_val_locked(signal_op->semaphore.obj, signal_op->semaphore.phys_val);
             d3d12_semaphore_unlock(signal_op->semaphore.obj);
+        }
+        else
+        {
+            fence = wine_fence_to_handle(signal_op->fence);
+
+            if (!device_lost && (vr = thunk_vkWaitForFences(queue->device, 1, &fence, VK_TRUE, -1)) < 0)
+            {
+                /* likely GPU hang */
+                fprintf(stderr, "winevulkan/queue_signaller_worker: Fence wait failed, vr %d.\n", vr);
+                continue;
+            }
+
+            buf = 1;
+            assert( write(signal_op->fence->eventfd, &buf, sizeof(buf)) != -1 );
         }
 
         free(signal_op);
@@ -5170,6 +5192,7 @@ struct queue_submit_unit
     uint32_t submit_count;
     VkSubmitInfo *submits;
     VkSubmitInfo2 *submits2;
+    VkFence fence;
     bool khr;
 
     struct pending_wait **waits;
@@ -5258,6 +5281,7 @@ static void *virtual_queue_worker(void *arg)
     struct signal_op *signal_op;
     struct wine_semaphore *sem;
     struct pending_wait *wait;
+    struct wine_fence *fence;
     bool device_lost = false;
     uint64_t *timeline_value;
     unsigned int i;
@@ -5310,13 +5334,13 @@ static void *virtual_queue_worker(void *arg)
         }
 
         if (submit_unit->submits)
-            vr = thunk_vkQueueSubmit(queue, submit_unit->submit_count, submit_unit->submits, VK_NULL_HANDLE);
+            vr = thunk_vkQueueSubmit(queue, submit_unit->submit_count, submit_unit->submits, submit_unit->fence);
         else
         {
             if (submit_unit->khr)
-                vr = thunk_vkQueueSubmit2KHR(queue, submit_unit->submit_count, submit_unit->submits2, VK_NULL_HANDLE);
+                vr = thunk_vkQueueSubmit2KHR(queue, submit_unit->submit_count, submit_unit->submits2, submit_unit->fence);
             else
-                vr = thunk_vkQueueSubmit2(queue, submit_unit->submit_count, submit_unit->submits2, VK_NULL_HANDLE);
+                vr = thunk_vkQueueSubmit2(queue, submit_unit->submit_count, submit_unit->submits2, submit_unit->fence);
         }
 
         pthread_mutex_lock(&queue->signaller_mutex);
@@ -5344,6 +5368,15 @@ static void *virtual_queue_worker(void *arg)
             d3d12_semaphore_unlock(sem);
         }
 
+        if (vr == VK_SUCCESS && (fence = wine_fence_from_handle(submit_unit->fence)))
+        {
+            signal_op = malloc(sizeof(*signal_op));
+            signal_op->signal_type = SIGNAL_TYPE_FENCE;
+            signal_op->fence = fence;
+
+            list_add_tail(&queue->signal_ops, &signal_op->entry);
+        }
+
         pthread_cond_signal(&queue->signaller_cond);
         pthread_mutex_unlock(&queue->signaller_mutex);
 
@@ -5353,6 +5386,12 @@ static void *virtual_queue_worker(void *arg)
             pthread_mutex_lock(&queue->submissions_mutex);
             queue->device_lost = device_lost = true;
             pthread_mutex_unlock(&queue->submissions_mutex);
+
+            if ((fence = wine_fence_from_handle(submit_unit->fence)))
+            {
+                uint64_t buf = 1;
+                assert( write(fence->eventfd, &buf, sizeof(buf)) != -1 );
+            }
         }
 
 free_submit_unit:
@@ -5408,12 +5447,6 @@ static NTSTATUS virtual_queue_submit(struct VkQueue_T *queue, uint32_t submit_co
     uint64_t wait_value;
     bool device_lost;
 
-    if (fence != VK_NULL_HANDLE)
-    {
-        FIXME("Signalling fences in queue submissions involving D3D12-Fence compatible timeline semaphores not supported.\n");
-        return VK_ERROR_OUT_OF_HOST_MEMORY;
-    }
-
     init_virtual_queue(queue);
 
     pthread_mutex_lock(&queue->submissions_mutex);
@@ -5426,6 +5459,7 @@ static NTSTATUS virtual_queue_submit(struct VkQueue_T *queue, uint32_t submit_co
     submit_unit->submit_count = submit_count;
     submit_unit->submits = copy_VkSubmitInfo(submits, submit_count);
     submit_unit->submits2 = NULL;
+    submit_unit->fence = fence;
     submit_unit->waits = NULL;
     submit_unit->khr = queue->device->phys_dev->api_version < VK_API_VERSION_1_2 ||
                        queue->device->phys_dev->instance->api_version < VK_API_VERSION_1_2;
@@ -5485,6 +5519,11 @@ static NTSTATUS virtual_queue_submit(struct VkQueue_T *queue, uint32_t submit_co
 
     pthread_mutex_lock(&queue->submissions_mutex);
     queue->processing = true;
+    if (fence)
+    {
+        wine_fence_from_handle(fence)->queue = queue;
+        wine_fence_from_handle(fence)->wait_assist = true;
+    }
     list_add_tail(&queue->submissions, &submit_unit->entry);
     pthread_cond_signal(&queue->submissions_cond);
     pthread_mutex_unlock(&queue->submissions_mutex);
@@ -5523,6 +5562,9 @@ NTSTATUS wine_vkQueueSubmit(void *args)
                 return virtual_queue_submit(queue, submit_count, submits, fence);
         }
     }
+
+    if (fence)
+        wine_fence_from_handle(fence)->queue = queue;
 
     return thunk_vkQueueSubmit(queue, submit_count, submits, fence);
 }
@@ -5622,6 +5664,9 @@ static NTSTATUS vk_queue_submit_2(VkQueue queue, uint32_t submit_count, const Vk
                 return virtual_queue_submit2(queue, submit_count, submits, fence, khr);
         }
     }
+
+    if (fence)
+        wine_fence_from_handle(fence)->queue = queue;
 
     if (khr)
         return thunk_vkQueueSubmit2KHR(queue, submit_count, submits, fence);
@@ -5764,6 +5809,190 @@ NTSTATUS wine_vkQueueBindSparse(void *args)
     }
 
     return thunk_vkQueueBindSparse(queue, bind_info_count, bind_info, fence);
+}
+
+NTSTATUS wine_vkCreateFence(void *args)
+{
+    struct vkCreateFence_params *params = args;
+    VkDevice device = params->device;
+    const VkFenceCreateInfo *create_info = params->pCreateInfo;
+    const VkAllocationCallbacks *allocator = params->pAllocator;
+    VkFence *fence = params->pFence;
+
+    struct wine_fence *object;
+    VkResult vr;
+
+    TRACE("(%p, %p, %p, %p)\n", device, create_info, allocator, fence);
+
+    if (allocator)
+        FIXME("Support for allocation callbacks not implemented yet\n");
+
+    if (!(object = calloc(1, sizeof(*object))))
+        return VK_ERROR_OUT_OF_HOST_MEMORY;
+
+    if ((object->eventfd = eventfd(0, EFD_CLOEXEC)) == -1)
+        ERR("Failed to create eventfd for fence.\n");
+
+    if ((vr = device->funcs.p_vkCreateFence(device->device, create_info, allocator, &object->fence)) == VK_SUCCESS)
+        *fence = wine_fence_to_handle(object);
+    else
+        free(object);
+
+    return vr;
+}
+
+NTSTATUS wine_vkDestroyFence(void *args)
+{
+    struct vkDestroyFence_params *params = args;
+    VkDevice device = params->device;
+    VkFence handle = params->fence;
+    const VkAllocationCallbacks *allocator = params->pAllocator;
+
+    struct wine_fence *fence = wine_fence_from_handle(handle);
+
+    TRACE("(%p, %p, %p)\n", device, fence, allocator);
+
+    if (allocator)
+        FIXME("Support for allocation callbacks not implemented yet\n");
+
+    if (fence->eventfd != -1)
+        close(fence->eventfd);
+
+    device->funcs.p_vkDestroyFence(device->device, fence->fence, allocator);
+    free(fence);
+
+    return STATUS_SUCCESS;
+}
+
+NTSTATUS wine_vkResetFences(void *args)
+{
+    struct vkResetFences_params *params = args;
+    VkDevice device = params->device;
+    uint32_t fence_count = params->fenceCount;
+    const VkFence *fences = params->pFences;
+
+    struct wine_fence *fence;
+    unsigned int i;
+    uint64_t buf;
+    VkResult vr;
+
+    TRACE("(%p, %u, %p)\n", device, fence_count, fences);
+
+    if ((vr = thunk_vkResetFences(device, fence_count, fences)) != VK_SUCCESS)
+        return vr;
+
+    for (i = 0; i < fence_count; i++)
+    {
+        fence = wine_fence_from_handle(fences[i]);
+
+        fence->queue = NULL;
+        fence->swapchain = NULL;
+        if (fence->wait_assist)
+        {
+            fence->wait_assist = false;
+            if (read(fence->eventfd, &buf, sizeof(buf)) == -1)
+                ERR("Failed to reset event fd.\n");
+        }
+    }
+
+    return VK_SUCCESS;
+}
+
+NTSTATUS wine_vkWaitForFences(void *args)
+{
+    struct vkWaitForFences_params *params = args;
+    VkDevice device = params->device;
+    uint32_t fence_count = params->fenceCount;
+    const VkFence *fences = params->pFences;
+    VkBool32 wait_all = params->waitAll;
+    uint64_t timeout = params->timeout;
+
+    struct signal_op *signal_op;
+    bool assisted_wait = false;
+    struct wine_fence *fence;
+    struct pollfd *wait_fds;
+    struct pollfd wait_fd;
+    unsigned int i;
+    VkResult vr;
+
+    TRACE("(%p, %u, %p, %u, 0x%s)\n", device, fence_count, fences, wait_all, wine_dbgstr_longlong(timeout));
+
+    for (i = 0; i < fence_count; i++)
+    {
+        fence = wine_fence_from_handle(fences[i]);
+        if (!fence->wait_assist)
+            continue;
+
+        if (!wait_all && fence_count > 1)
+        {
+            assisted_wait = true;
+            break;
+        }
+
+        wait_fd.fd = fence->eventfd;
+        wait_fd.events = POLLIN;
+        if (poll(&wait_fd, 1, timeout / 1000000) == -1)
+        {
+            ERR("Failed to poll wait assisted fence.\n");
+            return VK_ERROR_OUT_OF_HOST_MEMORY;
+        }
+    }
+
+    if (assisted_wait)
+    {
+        /* Turn all non assisted waits into assisted waits, then poll on all */
+        wait_fds = malloc( sizeof(wait_fds[0]) * fence_count );
+
+        for (i = 0; i < fence_count; i++)
+        {
+            if (!fence->wait_assist)
+            {
+                assert(fence->queue || fence->swapchain);
+
+                if (fence->queue)
+                {
+                    fence->wait_assist = true;
+
+                    /* If virtual-queue requiring work was submitted after the work signalling this mutex,
+                     * we will end up unnecessarily waiting on that work first,
+                     * but this will only happen once per queue */
+                    init_virtual_queue(fence->queue);
+
+                    signal_op = malloc(sizeof(*signal_op));
+                    signal_op->signal_type = SIGNAL_TYPE_FENCE;
+                    signal_op->fence = fence;
+
+                    pthread_mutex_lock(&fence->queue->signaller_mutex);
+                    list_add_tail(&fence->queue->signal_ops, &signal_op->entry);
+                    pthread_cond_signal(&fence->queue->signaller_cond);
+                    pthread_mutex_unlock(&fence->queue->signaller_mutex);
+                }
+                else
+                {
+                    FIXME("Wait assist for swapchain signaled fences not supported.\n");
+                    free(wait_fds);
+                    return VK_ERROR_OUT_OF_HOST_MEMORY;
+                }
+            }
+
+            wait_fds[i].fd = fence->eventfd;
+            wait_fds[i].events = POLLIN;
+        }
+
+        if (poll(wait_fds, fence_count, timeout / 1000000) == -1)
+        {
+            ERR("Failed to poll wait assisted fences.\n");
+            vr = VK_ERROR_OUT_OF_HOST_MEMORY;
+        }
+
+        free(wait_fds);
+    }
+    else
+    {
+        vr = thunk_vkWaitForFences(device, fence_count, fences, wait_all, timeout);
+    }
+
+    return vr;
 }
 
 NTSTATUS wine_vkQueueWaitIdle(void *args)

--- a/dlls/winevulkan/vulkan.c
+++ b/dlls/winevulkan/vulkan.c
@@ -26,6 +26,7 @@
 #include <time.h>
 #include <stdlib.h>
 #include <unistd.h>
+#include <stdbool.h>
 
 #include "ntstatus.h"
 #define WIN32_NO_STATUS
@@ -450,10 +451,10 @@ static char **parse_xr_extensions(unsigned int *len)
     return list;
 }
 
-static VkResult wine_vk_device_convert_create_info(const VkDeviceCreateInfo *src,
+static VkResult wine_vk_device_convert_create_info(VkPhysicalDevice phys_dev, const VkDeviceCreateInfo *src,
         VkDeviceCreateInfo *dst, BOOL *must_free_extensions)
 {
-    unsigned int i, append_xr = 0, replace_win32 = 0, wine_extension_count;
+    unsigned int i, append_xr = 0, replace_win32 = 0, timeline_enabled = 0, wine_extension_count;
     VkResult res;
 
     static const char *wine_xr_extension_name = "VK_WINE_openxr_device_extensions";
@@ -474,29 +475,23 @@ static VkResult wine_vk_device_convert_create_info(const VkDeviceCreateInfo *src
     {
         const char *extension_name = dst->ppEnabledExtensionNames[i];
         if (!strcmp(extension_name, wine_xr_extension_name))
-        {
             append_xr = 1;
-            break;
-        }
-    }
-    for (i = 0; i < src->enabledExtensionCount; i++)
-    {
-        if (!strcmp(src->ppEnabledExtensionNames[i], "VK_KHR_external_memory_win32") || !strcmp(src->ppEnabledExtensionNames[i], "VK_KHR_external_semaphore_win32"))
-        {
+        else if (!strcmp(extension_name, "VK_KHR_external_memory_win32") || !strcmp(extension_name, "VK_KHR_external_semaphore_win32"))
             replace_win32 = 1;
-            break;
-        }
+        else if (!strcmp(extension_name, "VK_KHR_timeline_semaphore"))
+            timeline_enabled = 1;
     }
+
     if (append_xr || replace_win32)
     {
-        unsigned int xr_extensions_len = 0, o = 0;
+        unsigned int xr_extensions_len = 0, o = 0, j;
         char **xr_extensions_list = NULL;
         char **new_extensions_list;
 
         if (append_xr)
             xr_extensions_list = parse_xr_extensions(&xr_extensions_len);
 
-        new_extensions_list = malloc(sizeof(char *) * (dst->enabledExtensionCount + xr_extensions_len));
+        new_extensions_list = malloc(sizeof(char *) * (dst->enabledExtensionCount + xr_extensions_len + replace_win32));
 
         if(append_xr && !xr_extensions_list)
             WARN("Requested to use XR extensions, but none are set!\n");
@@ -509,7 +504,23 @@ static VkResult wine_vk_device_convert_create_info(const VkDeviceCreateInfo *src
             if (replace_win32 && !strcmp(src->ppEnabledExtensionNames[i], "VK_KHR_external_memory_win32"))
                 new_extensions_list[o] = strdup("VK_KHR_external_memory_fd");
             else if (replace_win32 && !strcmp(src->ppEnabledExtensionNames[i], "VK_KHR_external_semaphore_win32"))
+            {
                 new_extensions_list[o] = strdup("VK_KHR_external_semaphore_fd");
+
+                /* D3D12-Fence interoperable semaphores are implemented using timeline semaphores */
+                if (!timeline_enabled && (phys_dev->api_version < VK_API_VERSION_1_2 || phys_dev->instance->api_version < VK_API_VERSION_1_2))
+                {
+                    for (j = 0; j < phys_dev->extension_count; j++)
+                    {
+                        if (!strcmp(phys_dev->extensions[j].extensionName, "VK_KHR_timeline_semaphore"))
+                        {
+                            new_extensions_list[++o] = strdup("VK_KHR_timeline_semaphore");
+                            break;
+                        }
+                    }
+                }
+
+            }
             else
                 new_extensions_list[o] = strdup(dst->ppEnabledExtensionNames[i]);
             ++o;
@@ -874,7 +885,7 @@ VkResult WINAPI __wine_create_vk_device_with_callback(VkPhysicalDevice phys_dev,
     object->base.base.loader_magic = VULKAN_ICD_MAGIC_VALUE;
     object->phys_dev = phys_dev;
 
-    res = wine_vk_device_convert_create_info(create_info, &create_info_host, &create_info_free_extensions);
+    res = wine_vk_device_convert_create_info(phys_dev, create_info, &create_info_host, &create_info_free_extensions);
     if (res != VK_SUCCESS)
         goto fail;
 
@@ -887,7 +898,7 @@ VkResult WINAPI __wine_create_vk_device_with_callback(VkPhysicalDevice phys_dev,
                 &create_info_host, NULL /* allocator */, &object->device);
 
     wine_vk_device_free_create_info(&create_info_host);
-    if(create_info_free_extensions)
+    if (create_info_free_extensions)
         wine_vk_device_free_create_info_extensions(&create_info_host);
     WINE_VK_ADD_DISPATCHABLE_MAPPING(phys_dev->instance, object, object->device);
     if (res != VK_SUCCESS)
@@ -1776,29 +1787,90 @@ static void wine_vk_get_physical_device_external_semaphore_properties(VkPhysical
     void (*p_vkGetPhysicalDeviceExternalSemaphoreProperties)(VkPhysicalDevice, const VkPhysicalDeviceExternalSemaphoreInfo *, VkExternalSemaphoreProperties *),
     const VkPhysicalDeviceExternalSemaphoreInfo *semaphore_info, VkExternalSemaphoreProperties *properties)
 {
-    VkPhysicalDeviceExternalSemaphoreInfo semaphore_info_dup = *semaphore_info;
+    VkPhysicalDeviceExternalSemaphoreInfo semaphore_info_dup = *semaphore_info, semaphore_info_host;
+    VkSemaphoreTypeCreateInfo semaphore_type_info, *p_semaphore_type_info;
+    unsigned int i;
+    VkResult res;
 
-    wine_vk_normalize_semaphore_handle_types_win(&semaphore_info_dup.handleType);
-    if (semaphore_info_dup.handleType == VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_WIN32_BIT)
-        semaphore_info_dup.handleType = VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_FD_BIT;
-    wine_vk_normalize_semaphore_handle_types_host(&semaphore_info_dup.handleType);
-
-    if (semaphore_info->handleType && !semaphore_info_dup.handleType)
+    if ((res = convert_VkPhysicalDeviceExternalSemaphoreInfo_struct_chain(semaphore_info->pNext, &semaphore_info_dup)) < 0)
     {
+        WARN("Failed to convert VkPhysicalDeviceExternalSemaphoreInfo pNext chain, res=%d.\n", res);
+
         properties->exportFromImportedHandleTypes = 0;
         properties->compatibleHandleTypes = 0;
         properties->externalSemaphoreFeatures = 0;
         return;
     }
 
-    p_vkGetPhysicalDeviceExternalSemaphoreProperties(phys_dev->phys_dev, &semaphore_info_dup, properties);
+    semaphore_info_host = semaphore_info_dup;
+
+    switch(semaphore_info->handleType)
+    {
+        case VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_WIN32_BIT:
+            semaphore_info_host.handleType = VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_FD_BIT;
+            break;
+        case VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_D3D12_FENCE_BIT:
+        {
+            if (phys_dev->api_version < VK_API_VERSION_1_2 ||
+                phys_dev->instance->api_version < VK_API_VERSION_1_2)
+            {
+                for (i = 0; i < phys_dev->extension_count; i++)
+                {
+                    if (!strcmp(phys_dev->extensions[i].extensionName, "VK_KHR_timeline_semaphore"))
+                        break;
+                }
+                if (i == phys_dev->extension_count)
+                {
+                    free_VkPhysicalDeviceExternalSemaphoreInfo_struct_chain(&semaphore_info_dup);
+                    properties->exportFromImportedHandleTypes = 0;
+                    properties->compatibleHandleTypes = 0;
+                    properties->externalSemaphoreFeatures = 0;
+                    return;
+                }
+            }
+
+            if ((p_semaphore_type_info = wine_vk_find_struct(&semaphore_info_host, SEMAPHORE_TYPE_CREATE_INFO)))
+            {
+                p_semaphore_type_info->semaphoreType = VK_SEMAPHORE_TYPE_TIMELINE;
+                p_semaphore_type_info->initialValue = 0;
+            }
+            else
+            {
+                semaphore_type_info.sType = VK_STRUCTURE_TYPE_SEMAPHORE_TYPE_CREATE_INFO;
+                semaphore_type_info.pNext = semaphore_info_host.pNext;
+                semaphore_type_info.semaphoreType = VK_SEMAPHORE_TYPE_TIMELINE;
+                semaphore_type_info.initialValue = 0;
+
+                semaphore_info_host.pNext = &semaphore_type_info;
+            }
+
+            semaphore_info_host.handleType = VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_FD_BIT;
+            break;
+        }
+        default:
+            semaphore_info_host.handleType = 0;
+    }
+
+    if (semaphore_info->handleType && !semaphore_info_host.handleType)
+    {
+        free_VkPhysicalDeviceExternalSemaphoreInfo_struct_chain(&semaphore_info_dup);
+
+        properties->exportFromImportedHandleTypes = 0;
+        properties->compatibleHandleTypes = 0;
+        properties->externalSemaphoreFeatures = 0;
+        return;
+    }
+
+    p_vkGetPhysicalDeviceExternalSemaphoreProperties(phys_dev->phys_dev, &semaphore_info_host, properties);
+
+    free_VkPhysicalDeviceExternalSemaphoreInfo_struct_chain(&semaphore_info_dup);
 
     if (properties->exportFromImportedHandleTypes & VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_FD_BIT)
-        properties->exportFromImportedHandleTypes |= VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_WIN32_BIT;
+        properties->exportFromImportedHandleTypes = semaphore_info->handleType;
     wine_vk_normalize_semaphore_handle_types_win(&properties->exportFromImportedHandleTypes);
 
     if (properties->compatibleHandleTypes & VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_FD_BIT)
-        properties->compatibleHandleTypes |= VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_WIN32_BIT;
+        properties->compatibleHandleTypes = semaphore_info->handleType;
     wine_vk_normalize_semaphore_handle_types_win(&properties->compatibleHandleTypes);
 }
 
@@ -2844,7 +2916,7 @@ NTSTATUS wine_vkAcquireNextImage2KHR(void *args)
     image_info_host.pNext = pAcquireInfo->pNext;
     image_info_host.swapchain = object->swapchain;
     image_info_host.timeout = pAcquireInfo->timeout;
-    image_info_host.semaphore = pAcquireInfo->semaphore;
+    image_info_host.semaphore = wine_semaphore_from_handle(pAcquireInfo->semaphore)->semaphore;
     image_info_host.fence = pAcquireInfo->fence;
     image_info_host.deviceMask = pAcquireInfo->deviceMask;
 
@@ -3338,11 +3410,8 @@ static VkResult record_graphics_cmd(VkDevice device, struct VkSwapchainKHR_T *sw
     return VK_SUCCESS;
 }
 
-NTSTATUS wine_vkQueuePresentKHR(void *args)
+static VkResult fshack_vk_queue_present(VkQueue queue, const VkPresentInfoKHR *pPresentInfo)
 {
-    struct vkQueuePresentKHR_params *params = args;
-    VkQueue queue = params->queue;
-    const VkPresentInfoKHR *pPresentInfo = params->pPresentInfo;
     VkResult res;
     VkPresentInfoKHR our_presentInfo;
     VkSwapchainKHR *arr;
@@ -4084,6 +4153,50 @@ NTSTATUS wine_vkCreateImage(void *args)
     return res;
 }
 
+#define IOCTL_SHARED_GPU_RESOURCE_SET_OBJECT           CTL_CODE(FILE_DEVICE_VIDEO, 6, METHOD_BUFFERED, FILE_WRITE_ACCESS)
+
+static bool set_shared_resource_object(HANDLE shared_resource, unsigned int index, HANDLE handle)
+{
+    IO_STATUS_BLOCK iosb;
+    struct shared_resource_set_object
+    {
+        unsigned int index;
+        obj_handle_t handle;
+    } params;
+
+    params.index = index;
+    params.handle = wine_server_obj_handle(handle);
+
+    return NtDeviceIoControlFile(shared_resource, NULL, NULL, NULL, &iosb, IOCTL_SHARED_GPU_RESOURCE_SET_OBJECT,
+            &params, sizeof(params), NULL, 0) == STATUS_SUCCESS;
+}
+
+#define IOCTL_SHARED_GPU_RESOURCE_GET_OBJECT           CTL_CODE(FILE_DEVICE_VIDEO, 6, METHOD_BUFFERED, FILE_READ_ACCESS)
+
+static HANDLE get_shared_resource_object(HANDLE shared_resource, unsigned int index)
+{
+    IO_STATUS_BLOCK iosb;
+    obj_handle_t handle;
+
+    if (NtDeviceIoControlFile(shared_resource, NULL, NULL, NULL, &iosb, IOCTL_SHARED_GPU_RESOURCE_GET_OBJECT,
+            &index, sizeof(index), &handle, sizeof(handle)))
+        return NULL;
+
+    return wine_server_ptr_handle(handle);
+}
+
+static void d3d12_semaphore_lock(struct wine_semaphore *semaphore)
+{
+    assert( semaphore->handle_types & VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_D3D12_FENCE_BIT );
+    pthread_mutex_lock(&semaphore->d3d12_fence_shm->mutex);
+}
+
+static void d3d12_semaphore_unlock(struct wine_semaphore *semaphore)
+{
+    assert( semaphore->handle_types & VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_D3D12_FENCE_BIT );
+    pthread_mutex_unlock(&semaphore->d3d12_fence_shm->mutex);
+}
+
 NTSTATUS wine_vkCreateSemaphore(void *args)
 {
     struct vkCreateSemaphore_params *params = args;
@@ -4092,11 +4205,21 @@ NTSTATUS wine_vkCreateSemaphore(void *args)
     const VkAllocationCallbacks *allocator = params->pAllocator;
     VkSemaphore *semaphore = params->pSemaphore;
 
+    VkExportSemaphoreWin32HandleInfoKHR *export_handle_info = wine_vk_find_struct(create_info, EXPORT_SEMAPHORE_WIN32_HANDLE_INFO_KHR);
     VkSemaphoreCreateInfo create_info_host = *create_info;
     VkExportSemaphoreCreateInfo *export_semaphore_info;
+    VkSemaphoreGetFdInfoKHR_host fd_info;
+    pthread_mutexattr_t mutex_attr;
+    struct wine_semaphore *object;
+    pthread_condattr_t cond_attr;
+    OBJECT_ATTRIBUTES attr;
+    HANDLE section_handle;
+    LARGE_INTEGER li;
     VkResult res;
+    SIZE_T size;
+    int fd;
 
-    TRACE("%p %p %p %p", device, create_info, allocator, semaphore);
+    TRACE("(%p, %p, %p, %p)\n", device, create_info, allocator, semaphore);
 
     if (allocator)
         FIXME("Support for allocation callbacks not implemented yet\n");
@@ -4107,9 +4230,19 @@ NTSTATUS wine_vkCreateSemaphore(void *args)
         return res;
     }
 
+    if (!(object = calloc(1, sizeof(*object))))
+    {
+        free_VkSemaphoreCreateInfo_struct_chain(&create_info_host);
+        return VK_ERROR_OUT_OF_HOST_MEMORY;
+    }
+
+    object->semaphore = VK_NULL_HANDLE;
+    object->handle = INVALID_HANDLE_VALUE;
+
     if ((export_semaphore_info = wine_vk_find_struct(&create_info_host, EXPORT_SEMAPHORE_CREATE_INFO)))
     {
-        if (export_semaphore_info->handleTypes & VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_WIN32_BIT)
+        object->handle_types = export_semaphore_info->handleTypes;
+        if (export_semaphore_info->handleTypes & (VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_WIN32_BIT | VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_D3D12_FENCE_BIT))
             export_semaphore_info->handleTypes |= VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_FD_BIT;
         wine_vk_normalize_semaphore_handle_types_host(&export_semaphore_info->handleTypes);
     }
@@ -4117,7 +4250,84 @@ NTSTATUS wine_vkCreateSemaphore(void *args)
     if (wine_vk_find_struct(&create_info_host,  EXPORT_SEMAPHORE_WIN32_HANDLE_INFO_KHR))
         FIXME("VkExportSemaphoreWin32HandleInfoKHR unhandled.\n");
 
-    res = device->funcs.p_vkCreateSemaphore(device->device, &create_info_host, NULL, semaphore);
+    if ((res = device->funcs.p_vkCreateSemaphore(device->device, &create_info_host, NULL, &object->semaphore)) == VK_SUCCESS)
+    {
+        if (export_semaphore_info && export_semaphore_info->handleTypes == VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_FD_BIT)
+        {
+            fd_info.sType = VK_STRUCTURE_TYPE_SEMAPHORE_GET_FD_INFO_KHR;
+            fd_info.pNext = NULL;
+            fd_info.semaphore = object->semaphore;
+            fd_info.handleType = VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_FD_BIT;
+
+            if ((res = device->funcs.p_vkGetSemaphoreFdKHR(device->device, &fd_info, &fd)) == VK_SUCCESS)
+            {
+                object->handle = create_gpu_resource(fd, export_handle_info ? export_handle_info->name : NULL);
+                close(fd);
+            }
+
+            if (object->handle == INVALID_HANDLE_VALUE)
+            {
+                res = VK_ERROR_OUT_OF_HOST_MEMORY;
+                goto done;
+            }
+
+            if (object->handle_types & VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_D3D12_FENCE_BIT)
+            {
+                /* Shared Fence Memory */
+                InitializeObjectAttributes(&attr, NULL, 0, NULL, NULL);
+                size = li.QuadPart = sizeof(*object->d3d12_fence_shm);
+                if (NtCreateSection(&section_handle, STANDARD_RIGHTS_REQUIRED | SECTION_QUERY | SECTION_MAP_READ | SECTION_MAP_WRITE, &attr, &li, PAGE_READWRITE, SEC_COMMIT, NULL))
+                {
+                    res = VK_ERROR_OUT_OF_HOST_MEMORY;
+                    goto done;
+                }
+
+                if (!set_shared_resource_object(object->handle, 0, section_handle))
+                {
+                    NtClose(section_handle);
+                    res = VK_ERROR_OUT_OF_HOST_MEMORY;
+                    goto done;
+                }
+
+                if (NtMapViewOfSection(section_handle, GetCurrentProcess(), (void**) &object->d3d12_fence_shm, 0, 0, NULL, &size, ViewShare, 0, PAGE_READWRITE))
+                {
+                    NtClose(section_handle);
+                    res = VK_ERROR_OUT_OF_HOST_MEMORY;
+                    goto done;
+                }
+
+                NtClose(section_handle);
+
+                pthread_mutexattr_init(&mutex_attr);
+                pthread_mutexattr_setpshared(&mutex_attr, PTHREAD_PROCESS_SHARED);
+                pthread_mutexattr_settype(&mutex_attr, PTHREAD_MUTEX_ERRORCHECK);
+                if (pthread_mutex_init(&object->d3d12_fence_shm->mutex, &mutex_attr))
+                {
+                    pthread_mutexattr_destroy(&mutex_attr);
+                    res = VK_ERROR_OUT_OF_HOST_MEMORY;
+                    goto done;
+                }
+                pthread_mutexattr_destroy(&mutex_attr);
+            }
+        }
+
+        WINE_VK_ADD_NON_DISPATCHABLE_MAPPING(device->phys_dev->instance, object, object->semaphore);
+         *semaphore = wine_semaphore_to_handle(object);
+    }
+
+    done:
+
+    if (res != VK_SUCCESS)
+    {
+        pthread_mutex_destroy(&object->d3d12_fence_shm->mutex);
+        if (object->d3d12_fence_shm)
+            NtUnmapViewOfSection(GetCurrentProcess(), object->d3d12_fence_shm);
+        if (object->handle != INVALID_HANDLE_VALUE)
+            NtClose(object->handle);
+        if (object->semaphore != VK_NULL_HANDLE)
+            device->funcs.p_vkDestroySemaphore(device->device, object->semaphore, NULL);
+        free(object);
+    }
 
     free_VkSemaphoreCreateInfo_struct_chain(&create_info_host);
 
@@ -4127,33 +4337,49 @@ NTSTATUS wine_vkCreateSemaphore(void *args)
 NTSTATUS wine_vkGetSemaphoreWin32HandleKHR(void *args)
 {
     struct vkGetSemaphoreWin32HandleKHR_params *params = args;
-    VkDevice device = params->device;
     const VkSemaphoreGetWin32HandleInfoKHR *handle_info = params->pGetWin32HandleInfo;
     HANDLE *handle = params->pHandle;
 
-    VkSemaphoreGetFdInfoKHR_host fd_info;
-    VkResult res;
-    int fd;
+    struct wine_semaphore *semaphore = wine_semaphore_from_handle(handle_info->semaphore);
 
-    fd_info.sType = VK_STRUCTURE_TYPE_SEMAPHORE_GET_FD_INFO_KHR;
-    fd_info.pNext = handle_info->pNext;
-    fd_info.semaphore = handle_info->semaphore;
-    fd_info.handleType = handle_info->handleType;
-    if (fd_info.handleType == VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_WIN32_BIT)
-        fd_info.handleType = VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_FD_BIT;
-    wine_vk_normalize_semaphore_handle_types_host(&fd_info.handleType);
+    if (!(semaphore->handle_types & handle_info->handleType))
+        return VK_ERROR_INVALID_EXTERNAL_HANDLE;
 
-    res = device->funcs.p_vkGetSemaphoreFdKHR(device->device, &fd_info, &fd);
+    if (NtDuplicateObject( NtCurrentProcess(), semaphore->handle, NtCurrentProcess(), handle, 0, 0, DUPLICATE_SAME_ACCESS ))
+        return VK_ERROR_INVALID_EXTERNAL_HANDLE;
 
-    if (res != VK_SUCCESS)
-        return res;
+    return VK_SUCCESS;
+}
 
-    if (wine_server_fd_to_handle(fd, GENERIC_ALL, 0, handle) != STATUS_SUCCESS)
+NTSTATUS wine_vkDestroySemaphore(void *args)
+{
+    struct vkDestroySemaphore_params *params = args;
+    VkDevice device = params->device;
+    VkSemaphore handle = params->semaphore;
+    const VkAllocationCallbacks *allocator = params->pAllocator;
+
+    struct wine_semaphore *semaphore = wine_semaphore_from_handle(handle);
+
+    TRACE("%p 0x%s, %p\n", device, wine_dbgstr_longlong(handle), allocator);
+
+    if (allocator)
+        FIXME("Support for allocation callbacks not implemented yet\n");
+
+    if (!handle)
+        return VK_SUCCESS;
+
+    if (semaphore->handle_types & VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_D3D12_FENCE_BIT)
     {
-        close(fd);
-        return VK_ERROR_OUT_OF_HOST_MEMORY;
+        NtUnmapViewOfSection(GetCurrentProcess(), semaphore->d3d12_fence_shm);
     }
 
+    if (semaphore->handle_types)
+        NtClose(semaphore->handle);
+
+
+    WINE_VK_REMOVE_HANDLE_MAPPING(device->phys_dev->instance, semaphore);
+    device->funcs.p_vkDestroySemaphore(device->device, semaphore->semaphore, NULL);
+    free(semaphore);
     return VK_SUCCESS;
 }
 
@@ -4163,17 +4389,26 @@ NTSTATUS wine_vkImportSemaphoreWin32HandleKHR(void *args)
     VkDevice device = params->device;
     const VkImportSemaphoreWin32HandleInfoKHR *handle_info = params->pImportSemaphoreWin32HandleInfo;
 
+    struct wine_semaphore *semaphore = wine_semaphore_from_handle(handle_info->semaphore);
     VkImportSemaphoreFdInfoKHR_host fd_info;
+    HANDLE d3d12_fence_shm, sem_handle;
+    NTSTATUS stat;
     VkResult res;
-    int fd;
+    SIZE_T size;
+
+    TRACE("(%p, %p)\n", device, handle_info);
+
+    if (!(semaphore->handle_types & handle_info->handleType))
+        return VK_ERROR_INVALID_EXTERNAL_HANDLE;
 
     fd_info.sType = VK_STRUCTURE_TYPE_IMPORT_SEMAPHORE_FD_INFO_KHR;
     fd_info.pNext = handle_info->pNext;
-    fd_info.semaphore = handle_info->semaphore;
+    fd_info.semaphore = semaphore->semaphore;
     fd_info.flags = handle_info->flags;
     fd_info.handleType = handle_info->handleType;
 
-    if (fd_info.handleType == VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_WIN32_BIT)
+    if (handle_info->handleType == VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_WIN32_BIT ||
+        handle_info->handleType == VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_D3D12_FENCE_BIT)
     {
         if (handle_info->name)
         {
@@ -4181,10 +4416,53 @@ NTSTATUS wine_vkImportSemaphoreWin32HandleKHR(void *args)
             return VK_ERROR_INVALID_EXTERNAL_HANDLE;
         }
 
-        fd_info.handleType = VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_FD_BIT;
-        if (wine_server_handle_to_fd(handle_info->handle, GENERIC_ALL, &fd, NULL) != STATUS_SUCCESS)
+        if (NtDuplicateObject( NtCurrentProcess(), handle_info->handle, NtCurrentProcess(), &sem_handle, 0, 0, DUPLICATE_SAME_ACCESS ))
             return VK_ERROR_INVALID_EXTERNAL_HANDLE;
+
+        fd_info.handleType = VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_FD_BIT;
+        if ((fd_info.fd = get_shared_resource_fd(sem_handle)) == -1)
+        {
+            WARN("Invalid handle %p.\n", handle_info->handle);
+            NtClose(sem_handle);
+            return VK_ERROR_INVALID_EXTERNAL_HANDLE;
+        }
+
+        if (handle_info->handleType == VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_D3D12_FENCE_BIT)
+        {
+            if (handle_info->flags & VK_SEMAPHORE_IMPORT_TEMPORARY_BIT)
+            {
+                FIXME("Temporarily importing d3d12 fences unsupported.\n");
+                close(fd_info.fd);
+                NtClose(sem_handle);
+                return VK_ERROR_INVALID_EXTERNAL_HANDLE;
+            }
+
+            if (!(d3d12_fence_shm = get_shared_resource_object(sem_handle, 0)))
+            {
+                ERR("Failed to get D3D12 semaphore memory.\n");
+                close(fd_info.fd);
+                NtClose(sem_handle);
+                return VK_ERROR_OUT_OF_HOST_MEMORY;
+            }
+
+            semaphore->d3d12_fence_shm = NULL;
+            size = sizeof(*semaphore->d3d12_fence_shm);
+            if ((stat = NtMapViewOfSection(d3d12_fence_shm, GetCurrentProcess(), (void**) &semaphore->d3d12_fence_shm, 0, 0, NULL, &size, ViewShare, 0, PAGE_READWRITE)))
+            {
+                ERR("Failed to map D3D12 semaphore memory. stat %#x.\n", stat);
+                NtClose(d3d12_fence_shm);
+                close(fd_info.fd);
+                NtClose(sem_handle);
+                return VK_ERROR_OUT_OF_HOST_MEMORY;
+            }
+
+            NtClose(d3d12_fence_shm);
+        }
+
+        semaphore->current_type = handle_info->handleType;
+        semaphore->handle = sem_handle;
     }
+
     wine_vk_normalize_semaphore_handle_types_host(&fd_info.handleType);
 
     if (!fd_info.handleType)
@@ -4195,7 +4473,336 @@ NTSTATUS wine_vkImportSemaphoreWin32HandleKHR(void *args)
 
     /* importing FDs transfers ownership, importing NT handles does not  */
     if ((res = device->funcs.p_vkImportSemaphoreFdKHR(device->device, &fd_info)) != VK_SUCCESS)
-        close(fd);
+        close(fd_info.fd);
 
     return res;
+}
+
+
+static NTSTATUS vk_get_semaphore_counter_value(VkDevice device, VkSemaphore semaphore, uint64_t *value, bool khr);
+static NTSTATUS wine_vk_get_semaphore_counter_value(VkDevice device, VkSemaphore handle, uint64_t *value, bool khr)
+{
+    struct wine_semaphore *semaphore = wine_semaphore_from_handle(handle);
+
+    if (semaphore->handle_types & VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_D3D12_FENCE_BIT)
+    {
+        d3d12_semaphore_lock(semaphore);
+        *value = semaphore->d3d12_fence_shm->virtual_value;
+        d3d12_semaphore_unlock(semaphore);
+        return VK_SUCCESS;
+    }
+
+    return vk_get_semaphore_counter_value(device, handle, value, khr);
+}
+
+static NTSTATUS vk_get_semaphore_counter_value(VkDevice device, VkSemaphore semaphore, uint64_t *value, bool khr)
+{
+    if (khr)
+        return thunk_vkGetSemaphoreCounterValueKHR(device, semaphore, value);
+    else
+        return thunk_vkGetSemaphoreCounterValue(device, semaphore, value);
+}
+
+NTSTATUS wine_vkGetSemaphoreCounterValue(void *args)
+{
+    struct vkGetSemaphoreCounterValue_params *params = args;
+    VkDevice device = params->device;
+    VkSemaphore semaphore = params->semaphore;
+    uint64_t *value = params->pValue;
+
+    return wine_vk_get_semaphore_counter_value(device, semaphore, value, false);
+}
+
+NTSTATUS wine_vkGetSemaphoreCounterValueKHR(void *args)
+{
+    struct vkGetSemaphoreCounterValue_params *params = args;
+    VkDevice device = params->device;
+    VkSemaphore semaphore = params->semaphore;
+    uint64_t *value = params->pValue;
+
+    return wine_vk_get_semaphore_counter_value(device, semaphore, value, true);
+}
+
+static NTSTATUS vk_signal_semaphore(VkDevice device, const VkSemaphoreSignalInfo *signal_info, bool khr);
+static NTSTATUS wine_vk_signal_semaphore(VkDevice device, const VkSemaphoreSignalInfo *signal_info, bool khr)
+{
+    struct wine_semaphore *semaphore = wine_semaphore_from_handle(signal_info->semaphore);
+
+    TRACE("(%p, %p)\n", device, signal_info);
+
+    if (semaphore->handle_types & VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_D3D12_FENCE_BIT)
+    {
+        FIXME("Signalling D3D12-Fence compatible timeline semaphore not supported.\n");
+        return VK_ERROR_OUT_OF_HOST_MEMORY;
+    }
+
+    return vk_signal_semaphore(device, signal_info, khr);
+}
+
+static NTSTATUS vk_signal_semaphore(VkDevice device, const VkSemaphoreSignalInfo *signal_info, bool khr)
+{
+    if (khr)
+        return thunk_vkSignalSemaphoreKHR(device, signal_info);
+    else
+        return thunk_vkSignalSemaphore(device, signal_info);
+}
+
+NTSTATUS wine_vkSignalSemaphore(void *args)
+{
+    struct vkSignalSemaphore_params *params = args;
+    VkDevice device = params->device;
+    const VkSemaphoreSignalInfo *signal_info = params->pSignalInfo;
+
+    return wine_vk_signal_semaphore(device, signal_info, false);
+}
+
+NTSTATUS wine_vkSignalSemaphoreKHR(void *args)
+{
+    struct vkSignalSemaphore_params *params = args;
+    VkDevice device = params->device;
+    const VkSemaphoreSignalInfo *signal_info = params->pSignalInfo;
+
+    return wine_vk_signal_semaphore(device, signal_info, true);
+}
+
+static NTSTATUS vk_wait_semaphores(VkDevice device, const VkSemaphoreWaitInfo *wait_info, uint64_t timeout, bool khr);
+static NTSTATUS wine_vk_wait_semaphores(VkDevice device, const VkSemaphoreWaitInfo *wait_info, uint64_t timeout, bool khr)
+{
+    unsigned int i;
+
+    TRACE("(%p, %p, 0x%s)\n", device, wait_info, wine_dbgstr_longlong(timeout));
+
+    for (i = 0; i < wait_info->semaphoreCount; i++)
+    {
+        struct wine_semaphore *semaphore = wine_semaphore_from_handle(wait_info->pSemaphores[i]);
+
+        if (semaphore->handle_types & VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_D3D12_FENCE_BIT)
+        {
+            FIXME("Waiting on D3D12-Fence compatible timeline semaphores not supported.");
+            return return VK_ERROR_OUT_OF_HOST_MEMORY;
+        }
+    }
+
+    return vk_wait_semaphores(device, wait_info, timeout, khr);
+}
+
+static NTSTATUS vk_wait_semaphores(VkDevice device, const VkSemaphoreWaitInfo *wait_info, uint64_t timeout, bool khr)
+{
+    if (khr)
+        return thunk_vkWaitSemaphoresKHR(device, wait_info, timeout);
+    else
+        return thunk_vkWaitSemaphores(device, wait_info, timeout);
+}
+
+NTSTATUS wine_vkWaitSemaphores(void *args)
+{
+    struct vkWaitSemaphores_params *params = args;
+    VkDevice device = params->device;
+    const VkSemaphoreWaitInfo *wait_info = params->pWaitInfo;
+    uint64_t timeout = params->timeout;
+
+    return wine_vk_wait_semaphores(device, wait_info, timeout, false);
+}
+
+NTSTATUS wine_vkWaitSemaphoresKHR(void *args)
+{
+    struct vkWaitSemaphores_params *params = args;
+    VkDevice device = params->device;
+    const VkSemaphoreWaitInfo *wait_info = params->pWaitInfo;
+    uint64_t timeout = params->timeout;
+
+    return wine_vk_wait_semaphores(device, wait_info, timeout, true);
+}
+
+NTSTATUS wine_vkQueueSubmit(void *args)
+{
+    struct vkQueueSubmit_params *params = args;
+    VkQueue queue = params->queue;
+    uint32_t submit_count = params->submitCount;
+    const VkSubmitInfo *submits = params->pSubmits;
+    VkFence fence = params->fence;
+
+    unsigned int i, k;
+
+    TRACE("(%p %u %p 0x%s)\n", queue, submit_count, submits, wine_dbgstr_longlong(fence));
+
+    for (i = 0; i < submit_count; i++)
+    {
+        for (k = 0; k < submits[i].waitSemaphoreCount; k++)
+        {
+            if (wine_semaphore_from_handle(submits[i].pWaitSemaphores[k])->handle_types &
+                    VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_D3D12_FENCE_BIT)
+            {
+                FIXME("Queue submissions with waits on D3D12-Fence compatible timeline semaphores not supported.\n");
+                return VK_ERROR_OUT_OF_HOST_MEMORY;
+            }
+        }
+
+        for (k = 0; k < submits[i].signalSemaphoreCount; k++)
+        {
+            if (wine_semaphore_from_handle(submits[i].pSignalSemaphores[k])->handle_types &
+                    VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_D3D12_FENCE_BIT)
+            {
+                FIXME("Queue submissions with signalling D3D12-Fence compatible timeline semaphores not supported.\n");
+                return VK_ERROR_OUT_OF_HOST_MEMORY;
+            }
+        }
+    }
+
+    return thunk_vkQueueSubmit(queue, submit_count, submits, fence);
+}
+
+static NTSTATUS vk_queue_submit_2(VkQueue queue, uint32_t submit_count, const VkSubmitInfo2 *submits, VkFence fence, bool khr)
+{
+    unsigned int i, k;
+
+    TRACE("(%p, %u, %p, %s)\n", queue, submit_count, submits, wine_dbgstr_longlong(fence));
+
+    for (i = 0; i < submit_count; i++)
+    {
+        for (k = 0; k < submits[i].waitSemaphoreInfoCount; k++)
+        {
+            if (wine_semaphore_from_handle(submits[i].pWaitSemaphoreInfos[k].semaphore)->handle_types &
+                    VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_D3D12_FENCE_BIT)
+            {
+                FIXME("Queue submissions with waits on D3D12-Fence compatible timeline semaphores not supported.\n");
+                return VK_ERROR_OUT_OF_HOST_MEMORY;
+            }
+        }
+
+        for (k = 0; k < submits[i].signalSemaphoreInfoCount; k++)
+        {
+            if (wine_semaphore_from_handle(submits[i].pSignalSemaphoreInfos[k].semaphore)->handle_types &
+                    VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_D3D12_FENCE_BIT)
+            {
+                FIXME("Queue submissions signalling D3D12-Fence compatible timeline semaphores not supported.\n");
+                return VK_ERROR_OUT_OF_HOST_MEMORY;
+            }
+        }
+    }
+
+    if (khr)
+        return thunk_vkQueueSubmit2KHR(queue, submit_count, submits, fence);
+    else
+        return thunk_vkQueueSubmit2(queue, submit_count, submits, fence);
+}
+
+NTSTATUS wine_vkQueueSubmit2(void *args)
+{
+    struct vkQueueSubmit2_params *params = args;
+    VkQueue queue = params->queue;
+    uint32_t submit_count = params->submitCount;
+    const VkSubmitInfo2 *submits = params->pSubmits;
+    VkFence fence = params->fence;
+
+    return vk_queue_submit_2(queue, submit_count, submits, fence, false);
+}
+
+NTSTATUS wine_vkQueueSubmit2KHR(void *args)
+{
+    struct vkQueueSubmit2_params *params = args;
+    VkQueue queue = params->queue;
+    uint32_t submit_count = params->submitCount;
+    const VkSubmitInfo2 *submits = params->pSubmits;
+    VkFence fence = params->fence;
+
+    return vk_queue_submit_2(queue, submit_count, submits, fence, true);
+}
+
+static inline VkSemaphore *convert_VkSemaphore_array_win_to_host(const VkSemaphore *in, uint32_t count)
+{
+    VkSemaphore *out;
+    unsigned int i;
+
+    if (!in || !count) return NULL;
+
+    out = malloc(count * sizeof(*out));
+    for (i = 0; i < count; i++)
+    {
+        out[i] = in[i] ? wine_semaphore_from_handle(in[i])->semaphore : VK_NULL_HANDLE;
+    }
+
+    return out;
+}
+
+static inline void free_VkSemaphore_array(VkSemaphore *in, uint32_t count)
+{
+    if (!in) return;
+
+    free(in);
+}
+
+NTSTATUS wine_vkQueuePresentKHR(void *args)
+{
+    struct vkQueuePresentKHR_params *params = args;
+    VkQueue queue = params->queue;
+    const VkPresentInfoKHR *present_info = params->pPresentInfo;
+
+    VkPresentInfoKHR host_present_info = *present_info;
+    struct wine_semaphore *semaphore;
+    VkSemaphore *host_semaphores;
+    unsigned int i;
+    VkResult vr;
+
+    TRACE("%p %p\n", queue, present_info);
+
+    for (i = 0; i < present_info->waitSemaphoreCount)
+    {
+        semaphore = wine_semaphore_from_handle(present_info->pWaitSemaphores);
+
+        if (semaphore->handle_types & VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_D3D12_FENCE_BIT)
+        {
+            FIXME("Waiting on D3D12-Fence compatible timeline semaphore not supported.\n");
+            return VK_ERROR_OUT_OF_HOST_MEMORY;
+        }
+    }
+
+    host_present_info.pWaitSemaphores = host_semaphores = convert_VkSemaphore_array_win_to_host(present_info->pWaitSemaphores, present_info->waitSemaphoreCount);
+    vr = fshack_vk_queue_present(queue, &host_present_info);
+    free_VkSemaphore_array(host_semaphores, present_info->waitSemaphoreCount);
+    return vr;
+}
+
+NTSTATUS wine_vkQueueBindSparse(void *args)
+{
+    struct vkQueueBindSparse_params *params = args;
+    VkQueue queue = params->queue;
+    uint32_t bind_info_count = params->bindInfoCount;
+    const VkBindSparseInfo *bind_info = params->pBindInfo;
+    VkFence fence = params->fence;
+
+    struct wine_semaphore *semaphore;
+    const VkBindSparseInfo *batch;
+    unsigned int i, k;
+
+    TRACE("(%p, %u, %p, 0x%s)\n", queue, bind_info_count, bind_info, wine_dbgstr_longlong(fence));
+
+    for (i = 0; i < bind_info_count; i++)
+    {
+        batch = &bind_info[i];
+
+        for (k = 0; k < batch->waitSemaphoreCount; k++)
+        {
+            semaphore = wine_semaphore_from_handle(batch->pWaitSemaphores[k]);
+
+            if (semaphore->handle_types & VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_D3D12_FENCE_BIT)
+            {
+                FIXME("Waiting on D3D12-Fence compatible timeline semaphore not supported.\n");
+                return VK_ERROR_OUT_OF_HOST_MEMORY;
+            }
+        }
+
+        for(k = 0; k < batch->signalSemaphoreCount; k++)
+        {
+            semaphore = wine_semaphore_from_handle(batch->pSignalSemaphores[k]);
+
+            if (semaphore->handle_types & VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_D3D12_FENCE_BIT)
+            {
+                FIXME("Signalling D3D12-Fence compatible timeline semaphore not supported.\n");
+                return VK_ERROR_OUT_OF_HOST_MEMORY;
+            }
+        }
+    }
+
+    return thunk_vkQueueBindSparse(queue, bind_info_count, bind_info, fence);
 }

--- a/dlls/winevulkan/vulkan.c
+++ b/dlls/winevulkan/vulkan.c
@@ -3719,6 +3719,15 @@ VkPhysicalDevice WINAPI __wine_get_native_VkPhysicalDevice(VkPhysicalDevice phys
 
 VkQueue WINAPI __wine_get_native_VkQueue(VkQueue queue)
 {
+    if (is_virtual_queue(queue))
+    {
+        FIXME("STEAMVR IS USING NATIVE HANDLE OF VIRTUALIZED QUEUE, THIS IS UNTESTED.\n");
+        pthread_mutex_lock(&queue->submissions_mutex);
+        while (queue->processing)
+            pthread_cond_wait(&queue->submissions_cond, &queue->submissions_mutex);
+        pthread_mutex_unlock(&queue->submissions_mutex);
+    }
+
     return queue->queue;
 }
 

--- a/dlls/winevulkan/vulkan.c
+++ b/dlls/winevulkan/vulkan.c
@@ -36,6 +36,7 @@
 #include "winnt.h"
 #include "winioctl.h"
 #include "wine/server.h"
+#include "wine/list.h"
 
 #include "vulkan_private.h"
 #include "winreg.h"
@@ -240,6 +241,11 @@ static struct VkPhysicalDevice_T *wine_vk_physical_device_alloc(struct VkInstanc
     struct VkPhysicalDevice_T *object;
     uint32_t num_host_properties, num_properties = 0;
     VkExtensionProperties *host_properties = NULL;
+#if defined(USE_STRUCT_CONVERSION)
+    VkPhysicalDeviceProperties_host physdev_properties;
+#else
+    VkPhysicalDeviceProperties physdev_properties;
+#endif
     VkResult res;
     unsigned int i, j;
 
@@ -249,6 +255,9 @@ static struct VkPhysicalDevice_T *wine_vk_physical_device_alloc(struct VkInstanc
     object->base.loader_magic = VULKAN_ICD_MAGIC_VALUE;
     object->instance = instance;
     object->phys_dev = phys_dev;
+
+    instance->funcs.p_vkGetPhysicalDeviceProperties(phys_dev, &physdev_properties);
+    object->api_version = physdev_properties.apiVersion;
 
     WINE_VK_ADD_DISPATCHABLE_MAPPING(instance, object, phys_dev);
 
@@ -368,6 +377,14 @@ static void wine_vk_device_get_queues(struct VkDevice_T *device,
         queue->family_index = family_index;
         queue->queue_index = i;
         queue->flags = flags;
+
+        pthread_mutex_init(&queue->submissions_mutex, NULL);
+        pthread_cond_init(&queue->submissions_cond, NULL);
+        list_init(&queue->submissions);
+
+        pthread_mutex_init(&queue->signaller_mutex, NULL);
+        pthread_cond_init(&queue->signaller_cond, NULL);
+        list_init(&queue->signal_ops);
 
         /* The Vulkan spec says:
          *
@@ -563,6 +580,10 @@ static void wine_vk_device_free_create_info_extensions(VkDeviceCreateInfo *creat
     free((void*)create_info->ppEnabledExtensionNames);
 }
 
+static bool is_virtual_queue(struct VkQueue_T *queue)
+{
+    return __atomic_load_n(&queue->virtual_queue, __ATOMIC_ACQUIRE);
+}
 
 /* Helper function used for freeing a device structure. This function supports full
  * and partial object cleanups and can thus be used for vkCreateDevice failures.
@@ -580,6 +601,28 @@ static void wine_vk_device_free(struct VkDevice_T *device)
         for (i = 0; i < device->queue_count; i++)
         {
             queue = &device->queues[i];
+
+            if (is_virtual_queue(queue))
+            {
+                pthread_mutex_lock(&queue->submissions_mutex);
+                pthread_mutex_lock(&queue->signaller_mutex);
+                queue->stop = 1;
+                pthread_mutex_unlock(&queue->submissions_mutex);
+                pthread_mutex_unlock(&queue->signaller_mutex);
+
+                pthread_cond_signal(&queue->submissions_cond);
+                pthread_cond_signal(&queue->signaller_cond);
+
+                pthread_join(queue->virtual_queue_thread, NULL);
+                pthread_join(queue->signal_thread, NULL);
+            }
+
+            pthread_mutex_destroy(&queue->submissions_mutex);
+            pthread_mutex_destroy(&queue->signaller_mutex);
+
+            pthread_cond_destroy(&queue->submissions_cond);
+            pthread_cond_destroy(&queue->signaller_cond);
+
             if (queue && queue->queue)
                 WINE_VK_REMOVE_HANDLE_MAPPING(device->phys_dev->instance, queue);
         }
@@ -1046,6 +1089,8 @@ VkResult WINAPI __wine_create_vk_instance_with_callback(const VkInstanceCreateIn
         TRACE("Engine name %s, engine version %#x.\n", debugstr_a(app_info->pEngineName),
                 app_info->engineVersion);
         TRACE("API version %#x.\n", app_info->apiVersion);
+
+        object->api_version = app_info->apiVersion;
 
         if (app_info->pEngineName && !strcmp(app_info->pEngineName, "idTech"))
             object->quirks |= WINEVULKAN_QUIRK_GET_DEVICE_PROC_ADDR;
@@ -4210,6 +4255,19 @@ static uint64_t d3d12_semaphore_try_get_wait_value_locked(struct wine_semaphore 
     if (semaphore->d3d12_fence_shm->virtual_value >= virtual_value)
         return 0;
 
+    for (i = 0; i < semaphore->d3d12_fence_shm->pending_updates_count; i++)
+    {
+        update = &semaphore->d3d12_fence_shm->pending_updates[i];
+
+        if (update->virtual_value < virtual_value)
+            continue;
+
+        if (update->signalling_pid == getpid() && waiting_queue && update->signalling_queue == waiting_queue)
+            return 0;
+
+        ret = min(ret, update->physical_value);
+    }
+
     return ret;
 }
 
@@ -4263,6 +4321,68 @@ static void d3d12_semaphore_satisfy_waits_locked(struct wine_semaphore *semaphor
             wait->physical_value = physical_value;
             pthread_cond_signal(&wait->cond);
         }
+    }
+}
+
+static uint64_t d3d12_semaphore_add_pending_signal_locked(struct wine_semaphore *semaphore, uint64_t virtual_value,
+        struct VkQueue_T *signalling_queue)
+{
+    struct pending_update *update;
+
+    if (semaphore->d3d12_fence_shm->pending_updates_count == ARRAY_SIZE(semaphore->d3d12_fence_shm->pending_updates))
+    {
+        FIXME("Failed to queue signal on d3d12 semaphore, maximum concurrent signals exceeded.\n");
+        return 0;
+    }
+
+    update = &semaphore->d3d12_fence_shm->pending_updates[
+        semaphore->d3d12_fence_shm->pending_updates_count++];
+
+    update->virtual_value = virtual_value;
+    update->physical_value = ++semaphore->d3d12_fence_shm->counter;
+    update->signalling_pid = getpid();
+    update->signalling_queue = signalling_queue;
+
+    return update->physical_value;
+}
+
+static struct pending_update d3d12_semaphore_peek_added_signal_locked(struct wine_semaphore *semaphore)
+{
+    return semaphore->d3d12_fence_shm->pending_updates[semaphore->d3d12_fence_shm->pending_updates_count - 1];
+}
+
+static bool d3d12_semaphore_pop_pending_signal_locked(struct wine_semaphore *semaphore, uint64_t phys_val, struct pending_update *ret)
+{
+    struct pending_update *update;
+    unsigned int i;
+
+    for (i = 0; i < semaphore->d3d12_fence_shm->pending_updates_count; i++)
+    {
+        if (semaphore->d3d12_fence_shm->pending_updates[i].physical_value == phys_val)
+        {
+            update = &semaphore->d3d12_fence_shm->pending_updates[i];
+            if (ret)
+                *ret = *update;
+            *update = semaphore->d3d12_fence_shm->pending_updates[--semaphore->d3d12_fence_shm->pending_updates_count];
+            return true;
+        }
+    }
+
+    return false;
+}
+
+static void d3d12_semaphore_update_phys_val_locked(struct wine_semaphore *sem, uint64_t phys_val)
+{
+    struct pending_update pending;
+
+    /* Based off linked VKD3D-Proton implementation, but we don't signal CPU waits here.
+        * https://github.com/HansKristian-Work/vkd3d-proton/blob/829ac72e3d381006a843c183e613e8ee77e0b292/libs/vkd3d/command.c#L758 */
+    while (sem->d3d12_fence_shm->physical_value < phys_val)
+    {
+        sem->d3d12_fence_shm->physical_value++;
+
+        if (d3d12_semaphore_pop_pending_signal_locked(sem, sem->d3d12_fence_shm->physical_value, &pending))
+            sem->d3d12_fence_shm->virtual_value = pending.virtual_value;
     }
 }
 
@@ -4604,6 +4724,7 @@ NTSTATUS wine_vkGetSemaphoreCounterValueKHR(void *args)
 static NTSTATUS vk_signal_semaphore(VkDevice device, const VkSemaphoreSignalInfo *signal_info, bool khr);
 static NTSTATUS wine_vk_signal_semaphore(VkDevice device, const VkSemaphoreSignalInfo *signal_info, bool khr)
 {
+    uint64_t phys_val;
     VkResult vr;
 
     struct wine_semaphore *semaphore = wine_semaphore_from_handle(signal_info->semaphore);
@@ -4612,27 +4733,41 @@ static NTSTATUS wine_vk_signal_semaphore(VkDevice device, const VkSemaphoreSigna
 
     if (semaphore->handle_types & VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_D3D12_FENCE_BIT)
     {
-        VkSemaphoreSignalInfo step_signal_info;
-
         d3d12_semaphore_lock(semaphore);
 
-        assert(semaphore->d3d12_fence_shm->counter == phys_val);
-        phys_val++;
-
-        semaphore->d3d12_fence_shm->counter = semaphore->d3d12_fence_shm->physical_value = phys_val;
-
-        step_signal_info.sType = VK_STRUCTURE_TYPE_SEMAPHORE_SIGNAL_INFO;
-        step_signal_info.pNext = NULL;
-        step_signal_info.semaphore = signal_info->semaphore;
-        step_signal_info.value = phys_val;
-
-        vr = vk_signal_semaphore(device, &step_signal_info, khr);
-        if (vr != VK_SUCCESS)
+        /* vkWaitSemaphore w/ WAIT_ANY wakes on every physical value increment to check if the wait is satisfied, so
+           if there are no scheduled signals, step the physical value */
+        if ((vr = vk_get_semaphore_counter_value(device, signal_info->semaphore, &phys_val, khr)) != VK_SUCCESS)
         {
             d3d12_semaphore_unlock(semaphore);
             return vr;
         }
 
+        d3d12_semaphore_update_phys_val_locked(semaphore, phys_val);
+
+        if (!semaphore->d3d12_fence_shm->pending_updates_count)
+        {
+            VkSemaphoreSignalInfo step_signal_info;
+
+            assert(semaphore->d3d12_fence_shm->counter == phys_val);
+            phys_val++;
+
+            semaphore->d3d12_fence_shm->counter = semaphore->d3d12_fence_shm->physical_value = phys_val;
+
+            step_signal_info.sType = VK_STRUCTURE_TYPE_SEMAPHORE_SIGNAL_INFO;
+            step_signal_info.pNext = NULL;
+            step_signal_info.semaphore = signal_info->semaphore;
+            step_signal_info.value = phys_val;
+
+            vr = vk_signal_semaphore(device, &step_signal_info, khr);
+            if (vr != VK_SUCCESS)
+            {
+                d3d12_semaphore_unlock(semaphore);
+                return vr;
+            }
+        }
+
+        /* If a queue is already waiting on the pending physical value of a previous submit, this won't wake it up. */
         d3d12_semaphore_satisfy_waits_locked(semaphore, signal_info->value, 0);
         semaphore->d3d12_fence_shm->virtual_value = signal_info->value;
 
@@ -4840,6 +4975,523 @@ NTSTATUS wine_vkWaitSemaphoresKHR(void *args)
     return wine_vk_wait_semaphores(device, wait_info, timeout, true);
 }
 
+struct signal_op
+{
+    enum
+    {
+        SIGNAL_TYPE_SEMAPHORE,
+    } signal_type;
+
+    union
+    {
+        struct
+        {
+            struct wine_semaphore *obj;
+            uint64_t phys_val;
+
+            bool khr;
+        } semaphore;
+    };
+
+    struct list entry;
+};
+
+static void *queue_signaller_worker(void *arg)
+{
+    struct VkQueue_T *queue = (struct VkQueue_T *)arg;
+    VkSemaphoreWaitInfo wait_info;
+    struct signal_op *signal_op;
+    VkSemaphore sem_handle;
+    bool device_lost;
+    VkResult vr;
+
+    for (;;)
+    {
+        pthread_mutex_lock(&queue->signaller_mutex);
+
+        while (!queue->stop && list_empty(&queue->signal_ops))
+            pthread_cond_wait(&queue->signaller_cond, &queue->signaller_mutex);
+
+        if (queue->stop)
+        {
+            assert( list_empty(&queue->signal_ops) );
+            pthread_mutex_unlock(&queue->signaller_mutex);
+            return NULL;
+        }
+
+        signal_op = LIST_ENTRY(list_head(&queue->signal_ops), struct signal_op, entry);
+        list_remove(&signal_op->entry);
+
+        device_lost = queue->device_lost;
+
+        pthread_mutex_unlock(&queue->signaller_mutex);
+
+        if (signal_op->signal_type == SIGNAL_TYPE_SEMAPHORE)
+        {
+            wait_info.sType = VK_STRUCTURE_TYPE_SEMAPHORE_WAIT_INFO;
+            wait_info.pNext = NULL;
+            wait_info.flags = 0;
+            wait_info.semaphoreCount = 1;
+            sem_handle = wine_semaphore_to_handle(signal_op->semaphore.obj);
+            wait_info.pSemaphores = &sem_handle;
+            wait_info.pValues = &signal_op->semaphore.phys_val;
+            if (!device_lost && (vr = vk_wait_semaphores(queue->device, &wait_info, -1, signal_op->semaphore.khr)) < 0)
+            {
+                /* likely GPU hang */
+                fprintf(stderr, "winevulkan/queue_signaller_worker: Semaphore wait failed, vr %d.\n", vr);
+                continue;
+            }
+
+            d3d12_semaphore_lock(signal_op->semaphore.obj);
+            d3d12_semaphore_update_phys_val_locked(signal_op->semaphore.obj, signal_op->semaphore.phys_val);
+            d3d12_semaphore_unlock(signal_op->semaphore.obj);
+        }
+
+        free(signal_op);
+    }
+
+    return NULL;
+}
+
+static VkSubmitInfo *copy_VkSubmitInfo(const VkSubmitInfo *in, uint32_t submit_count)
+{
+    VkSubmitInfo *out = malloc(sizeof(*out) * submit_count);
+    unsigned int i;
+
+    for (i = 0; i < submit_count; i++)
+    {
+        out[i].sType = in[i].sType;
+        out[i].waitSemaphoreCount = in[i].waitSemaphoreCount;
+        out[i].pWaitSemaphores = memdup(in[i].pWaitSemaphores, in[i].waitSemaphoreCount, sizeof(out[i].pWaitSemaphores[0]));
+        out[i].pWaitDstStageMask = memdup(in[i].pWaitDstStageMask, in[i].waitSemaphoreCount, sizeof(out[i].pWaitDstStageMask[0]));
+        out[i].commandBufferCount = in[i].commandBufferCount;
+        out[i].pCommandBuffers = memdup(in[i].pCommandBuffers, in[i].commandBufferCount, sizeof(out[i].pCommandBuffers[0]));
+        out[i].signalSemaphoreCount = in[i].signalSemaphoreCount;
+        out[i].pSignalSemaphores = memdup(in[i].pSignalSemaphores, in[i].signalSemaphoreCount, sizeof(out[i].pSignalSemaphores[0]));
+
+        convert_VkSubmitInfo_struct_chain(in[i].pNext, &out[i]);
+    }
+
+    return out;
+}
+
+static void free_copied_VkSubmitInfo(VkSubmitInfo *info, uint32_t submit_count)
+{
+    unsigned int i;
+
+    for (i = 0; i < submit_count; i++)
+    {
+        free_VkSubmitInfo_struct_chain(&info[i]);
+
+        free((VkSemaphore *)         info[i].pWaitSemaphores);
+        free((VkPipelineStageFlags*) info[i].pWaitDstStageMask);
+        free((VkCommandBuffer*)      info[i].pCommandBuffers);
+        free((VkSemaphore*)          info[i].pSignalSemaphores);
+    }
+
+    free(info);
+}
+
+static VkSubmitInfo2 *copy_VkSubmitInfo2(const VkSubmitInfo2 *in, uint32_t submit_count)
+{
+    VkSubmitInfo2 *out = malloc(sizeof(*out) * submit_count);
+    VkCommandBufferSubmitInfo *cmdbuf_submit_info;
+    VkSemaphoreSubmitInfo *sem_submit_info;
+    unsigned int i, k;
+
+    for (i = 0; i < submit_count; i++)
+    {
+        out[i].sType = in[i].sType;
+        out[i].flags = in[i].flags;
+
+        out[i].waitSemaphoreInfoCount = in[i].waitSemaphoreInfoCount;
+        out[i].pWaitSemaphoreInfos = sem_submit_info = memdup(in[i].pWaitSemaphoreInfos,
+                                            in[i].waitSemaphoreInfoCount,
+                                            sizeof(out[i].pWaitSemaphoreInfos[0]));
+        for (k = 0; k < out[i].waitSemaphoreInfoCount; k++)
+        {
+            if (sem_submit_info[k].pNext)
+            {
+                FIXME("pNext chain conversion for VkSemaphoreSubmitInfo not supported.\n");
+                sem_submit_info[k].pNext = NULL;
+            }
+        }
+
+        out[i].commandBufferInfoCount = in[i].commandBufferInfoCount;
+        out[i].pCommandBufferInfos = cmdbuf_submit_info = memdup(in[i].pCommandBufferInfos,
+                                            in[i].commandBufferInfoCount,
+                                            sizeof(out[i].pCommandBufferInfos[0]));
+        for (k = 0; k < out[i].commandBufferInfoCount; k++)
+        {
+            if (cmdbuf_submit_info[k].pNext)
+            {
+                FIXME("pNext chain conversion for VkCommandBufferSubmitInfo not supported.\n");
+                cmdbuf_submit_info[k].pNext = NULL;
+            }
+        }
+
+        out[i].signalSemaphoreInfoCount = in[i].signalSemaphoreInfoCount;
+        out[i].pSignalSemaphoreInfos = sem_submit_info =memdup(in[i].pSignalSemaphoreInfos,
+                                              in[i].signalSemaphoreInfoCount,
+                                              sizeof(out[i].pSignalSemaphoreInfos[0]));
+        for (k = 0; k < out[i].signalSemaphoreInfoCount; k++)
+        {
+            if (sem_submit_info[k].pNext)
+            {
+                FIXME("pNext chain conversion for VkSemaphoreSubmitInfo not supported.\n");
+                sem_submit_info[k].pNext = NULL;
+            }
+        }
+
+        convert_VkSubmitInfo2_struct_chain(in[i].pNext, &out[i]);
+    }
+
+    return out;
+}
+
+static void free_copied_VkSubmitInfo2(VkSubmitInfo2 *info, uint32_t submit_count)
+{
+    unsigned int i;
+
+    for (i = 0; i < submit_count; i++)
+    {
+        free_VkSubmitInfo2_struct_chain(&info[i]);
+
+        free((VkSemaphoreSubmitInfo  *)    info[i].pWaitSemaphoreInfos);
+        free((VkCommandBufferSubmitInfo *) info[i].pCommandBufferInfos);
+        free((VkSemaphoreSubmitInfo *)     info[i].pSignalSemaphoreInfos);
+    }
+
+    free(info);
+}
+
+struct queue_submit_unit
+{
+    uint32_t submit_count;
+    VkSubmitInfo *submits;
+    VkSubmitInfo2 *submits2;
+    bool khr;
+
+    struct pending_wait **waits;
+
+    struct list entry;
+};
+
+/* Abstracts away the differences between VkSubmitInfo and VkSubmitInfo2. */
+static bool for_each_d3d12_semaphore(struct queue_submit_unit *unit, bool signal,
+                                     struct wine_semaphore **semaphore_out, uint64_t **value_out, uint32_t counter)
+{
+    VkTimelineSemaphoreSubmitInfo *timeline_values;
+    struct wine_semaphore *semaphore;
+    unsigned int i, j, k;
+    uint32_t sem_count;
+
+    for (i = 0, k = 0; i < unit->submit_count; i++)
+    {
+        if (unit->submits)
+        {
+            timeline_values = wine_vk_find_struct(&unit->submits[i], TIMELINE_SEMAPHORE_SUBMIT_INFO);
+
+            if (signal)
+                sem_count = unit->submits[i].signalSemaphoreCount;
+            else
+                sem_count = unit->submits[i].waitSemaphoreCount;
+
+            for (j = 0; j < sem_count; j++)
+            {
+                if (signal)
+                    semaphore = wine_semaphore_from_handle(unit->submits[i].pSignalSemaphores[j]);
+                else
+                    semaphore = wine_semaphore_from_handle(unit->submits[i].pWaitSemaphores[j]);
+
+                if (!(semaphore->handle_types & VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_D3D12_FENCE_BIT))
+                    continue;
+
+                if (k++ == counter)
+                {
+                    *semaphore_out = semaphore;
+                    if (signal)
+                        *value_out = (uint64_t *) &timeline_values->pSignalSemaphoreValues[j];
+                    else
+                        *value_out = (uint64_t *) &timeline_values->pWaitSemaphoreValues[j];
+                    return true;
+                }
+            }
+        }
+        else
+        {
+            if (signal)
+                sem_count = unit->submits2[i].signalSemaphoreInfoCount;
+            else
+                sem_count = unit->submits2[i].waitSemaphoreInfoCount;
+
+            for (j = 0; j < sem_count; j++)
+            {
+                if (signal)
+                    semaphore = wine_semaphore_from_handle(unit->submits2[i].pSignalSemaphoreInfos[j].semaphore);
+                else
+                    semaphore = wine_semaphore_from_handle(unit->submits2[i].pWaitSemaphoreInfos[j].semaphore);
+
+                if (!(semaphore->handle_types & VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_D3D12_FENCE_BIT))
+                    continue;
+
+                if (k++ == counter)
+                {
+                    *semaphore_out = semaphore;
+                    if (signal)
+                        *value_out = (uint64_t *) &unit->submits2[i].pSignalSemaphoreInfos[j].value;
+                    else
+                        *value_out = (uint64_t *) &unit->submits2[i].pWaitSemaphoreInfos[j].value;
+                    return true;
+                }
+            }
+        }
+    }
+
+    return false;
+}
+
+static void *virtual_queue_worker(void *arg)
+{
+    struct VkQueue_T *queue = (struct VkQueue_T *)arg;
+    struct queue_submit_unit *submit_unit;
+    struct signal_op *signal_op;
+    struct wine_semaphore *sem;
+    struct pending_wait *wait;
+    bool device_lost = false;
+    uint64_t *timeline_value;
+    unsigned int i;
+    VkResult vr;
+
+    for (;;)
+    {
+        pthread_mutex_lock(&queue->submissions_mutex);
+
+        while (!queue->stop && list_empty(&queue->submissions))
+            pthread_cond_wait(&queue->submissions_cond, &queue->submissions_mutex);
+
+        if (queue->stop)
+        {
+            assert( list_empty(&queue->submissions) );
+            pthread_mutex_unlock(&queue->submissions_mutex);
+            return NULL;
+        }
+
+        submit_unit = LIST_ENTRY(list_head(&queue->submissions), struct queue_submit_unit, entry);
+        list_remove(&submit_unit->entry);
+
+        pthread_mutex_unlock(&queue->submissions_mutex);
+
+        if (device_lost)
+            goto free_submit_unit;
+
+        /* Wait for all fences to have a pending signal */
+        for (i = 0; for_each_d3d12_semaphore(submit_unit, false, &sem, &timeline_value, i); i++)
+        {
+            if ((wait = submit_unit->waits[i++]))
+            {
+                assert(wait);
+                d3d12_semaphore_lock(sem);
+
+                while (!wait->satisfied)
+                    pthread_cond_wait(&wait->cond, &sem->d3d12_fence_shm->mutex);
+
+                *timeline_value = d3d12_semaphore_pop_wait_locked(sem, wait);
+
+                d3d12_semaphore_unlock(sem);
+            }
+        }
+
+        for (i = 0; for_each_d3d12_semaphore(submit_unit, true, &sem, &timeline_value, i); i++)
+        {
+            d3d12_semaphore_lock(sem);
+
+            *timeline_value = d3d12_semaphore_add_pending_signal_locked(sem, *timeline_value, queue);
+        }
+
+        if (submit_unit->submits)
+            vr = thunk_vkQueueSubmit(queue, submit_unit->submit_count, submit_unit->submits, VK_NULL_HANDLE);
+        else
+        {
+            if (submit_unit->khr)
+                vr = thunk_vkQueueSubmit2KHR(queue, submit_unit->submit_count, submit_unit->submits2, VK_NULL_HANDLE);
+            else
+                vr = thunk_vkQueueSubmit2(queue, submit_unit->submit_count, submit_unit->submits2, VK_NULL_HANDLE);
+        }
+
+        pthread_mutex_lock(&queue->signaller_mutex);
+
+        for (i = 0; for_each_d3d12_semaphore(submit_unit, true, &sem, &timeline_value, i); i++)
+        {
+            if (vr == VK_SUCCESS)
+            {
+                struct pending_update added_signal = d3d12_semaphore_peek_added_signal_locked(sem);
+                d3d12_semaphore_satisfy_waits_locked(sem, added_signal.virtual_value, added_signal.physical_value);
+
+                signal_op = malloc(sizeof(*signal_op));
+                signal_op->signal_type = SIGNAL_TYPE_SEMAPHORE;
+                signal_op->semaphore.obj = sem;
+                signal_op->semaphore.phys_val = added_signal.physical_value;
+                signal_op->semaphore.khr = submit_unit->khr;
+
+                list_add_tail(&queue->signal_ops, &signal_op->entry);
+            }
+            else
+            {
+                d3d12_semaphore_pop_pending_signal_locked(sem, *timeline_value, NULL);
+            }
+
+            d3d12_semaphore_unlock(sem);
+        }
+
+        pthread_cond_signal(&queue->signaller_cond);
+        pthread_mutex_unlock(&queue->signaller_mutex);
+
+        if (vr != VK_SUCCESS)
+        {
+            fprintf(stderr, "winevulkan/virtual_queue_worker: queue submission failed with %d, treating as DEVICE_LOST.\n", vr);
+            pthread_mutex_lock(&queue->submissions_mutex);
+            queue->device_lost = device_lost = true;
+            pthread_mutex_unlock(&queue->submissions_mutex);
+        }
+
+free_submit_unit:
+        if (submit_unit->submits)
+            free_copied_VkSubmitInfo(submit_unit->submits, submit_unit->submit_count);
+        else
+            free_copied_VkSubmitInfo2(submit_unit->submits2, submit_unit->submit_count);
+        free(submit_unit->waits);
+        free(submit_unit);
+
+        pthread_mutex_lock(&queue->submissions_mutex);
+        if (list_empty(&queue->submissions))
+        {
+            queue->processing = false;
+        }
+        pthread_cond_signal(&queue->submissions_cond);
+        pthread_mutex_unlock(&queue->submissions_mutex);
+    }
+
+    return NULL;
+}
+
+static void init_virtual_queue(struct VkQueue_T *queue)
+{
+    if (is_virtual_queue(queue))
+        return;
+
+    pthread_mutex_lock(&queue->submissions_mutex);
+
+    if (queue->virtual_queue)
+    {
+        pthread_mutex_unlock(&queue->submissions_mutex);
+        return;
+    }
+
+    __atomic_store_n(&queue->virtual_queue, 1, __ATOMIC_RELEASE);
+
+    pthread_create(&queue->virtual_queue_thread, NULL, virtual_queue_worker, queue);
+    pthread_create(&queue->signal_thread, NULL, queue_signaller_worker, queue);
+
+    queue->virtual_queue = true;
+
+    pthread_mutex_unlock(&queue->submissions_mutex);
+}
+
+static NTSTATUS virtual_queue_submit(struct VkQueue_T *queue, uint32_t submit_count, const VkSubmitInfo *submits, VkFence fence)
+{
+    VkTimelineSemaphoreSubmitInfo *timeline_submit_info, *host_timeline_values;
+    VkD3D12FenceSubmitInfoKHR *d3d12_submit_info;
+    struct queue_submit_unit *submit_unit;
+    struct wine_semaphore *sem;
+    unsigned int i, j, k;
+    uint64_t wait_value;
+    bool device_lost;
+
+    if (fence != VK_NULL_HANDLE)
+    {
+        FIXME("Signalling fences in queue submissions involving D3D12-Fence compatible timeline semaphores not supported.\n");
+        return VK_ERROR_OUT_OF_HOST_MEMORY;
+    }
+
+    init_virtual_queue(queue);
+
+    pthread_mutex_lock(&queue->submissions_mutex);
+    device_lost = queue->device_lost;
+    pthread_mutex_unlock(&queue->submissions_mutex);
+    if (device_lost)
+        return VK_ERROR_DEVICE_LOST;
+
+    submit_unit = malloc(sizeof(*submit_unit));
+    submit_unit->submit_count = submit_count;
+    submit_unit->submits = copy_VkSubmitInfo(submits, submit_count);
+    submit_unit->submits2 = NULL;
+    submit_unit->waits = NULL;
+    submit_unit->khr = queue->device->phys_dev->api_version < VK_API_VERSION_1_2 ||
+                       queue->device->phys_dev->instance->api_version < VK_API_VERSION_1_2;
+
+    /* As D3D12 fences are rewindable, we add the wait synchronously as not to miss a temporarily signalled value
+     between vkQueueSubmit and processing the submit unit*/
+    for (i = 0, k = 0; i < submit_count; i++)
+    {
+        timeline_submit_info = wine_vk_find_struct(&submits[i], TIMELINE_SEMAPHORE_SUBMIT_INFO);
+        d3d12_submit_info = wine_vk_find_struct(&submits[i], D3D12_FENCE_SUBMIT_INFO_KHR);
+
+        host_timeline_values = wine_vk_find_struct(&submit_unit->submits[i], TIMELINE_SEMAPHORE_SUBMIT_INFO);
+
+        if (d3d12_submit_info && !host_timeline_values)
+        {
+            host_timeline_values = malloc(sizeof(*host_timeline_values));
+
+            host_timeline_values->sType = VK_STRUCTURE_TYPE_TIMELINE_SEMAPHORE_SUBMIT_INFO;
+            host_timeline_values->pNext = submit_unit->submits[i].pNext;
+            host_timeline_values->waitSemaphoreValueCount = d3d12_submit_info->waitSemaphoreValuesCount;
+            host_timeline_values->pWaitSemaphoreValues =
+                    memdup(d3d12_submit_info->pWaitSemaphoreValues, d3d12_submit_info->waitSemaphoreValuesCount,
+                        sizeof(host_timeline_values->pWaitSemaphoreValues[0]));
+            host_timeline_values->signalSemaphoreValueCount = d3d12_submit_info->signalSemaphoreValuesCount;
+            host_timeline_values->pSignalSemaphoreValues =
+                    memdup(d3d12_submit_info->pSignalSemaphoreValues, d3d12_submit_info->signalSemaphoreValuesCount,
+                        sizeof(host_timeline_values->pSignalSemaphoreValues[0]));
+
+            submit_unit->submits[i].pNext = host_timeline_values;
+        }
+
+        for (j = 0; j < submits[i].waitSemaphoreCount; j++)
+        {
+            sem = wine_semaphore_from_handle(submits[i].pWaitSemaphores[j]);
+
+            if (!(sem->handle_types & VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_D3D12_FENCE_BIT))
+                continue;
+
+            if (timeline_submit_info)
+                wait_value = timeline_submit_info->pWaitSemaphoreValues[j];
+            else
+                wait_value = d3d12_submit_info->pWaitSemaphoreValues[j];
+
+            submit_unit->waits = realloc(submit_unit->waits, (k + 1) * sizeof(*submit_unit->waits));
+            submit_unit->waits[k] = NULL;
+
+            d3d12_semaphore_lock(sem);
+
+            if ((((uint64_t*)host_timeline_values->pWaitSemaphoreValues)[j] =
+                                d3d12_semaphore_try_get_wait_value_locked(sem, wait_value, queue)) == -1)
+                submit_unit->waits[k] = d3d12_semaphore_push_wait_locked(sem, wait_value);
+
+            d3d12_semaphore_unlock(sem);
+            k++;
+        }
+    }
+
+    pthread_mutex_lock(&queue->submissions_mutex);
+    queue->processing = true;
+    list_add_tail(&queue->submissions, &submit_unit->entry);
+    pthread_cond_signal(&queue->submissions_cond);
+    pthread_mutex_unlock(&queue->submissions_mutex);
+
+    return VK_SUCCESS;
+}
+
 NTSTATUS wine_vkQueueSubmit(void *args)
 {
     struct vkQueueSubmit_params *params = args;
@@ -4852,30 +5504,97 @@ NTSTATUS wine_vkQueueSubmit(void *args)
 
     TRACE("(%p %u %p 0x%s)\n", queue, submit_count, submits, wine_dbgstr_longlong(fence));
 
+    if (is_virtual_queue(queue))
+        return virtual_queue_submit(queue, submit_count, submits, fence);
+
     for (i = 0; i < submit_count; i++)
     {
         for (k = 0; k < submits[i].waitSemaphoreCount; k++)
         {
             if (wine_semaphore_from_handle(submits[i].pWaitSemaphores[k])->handle_types &
                     VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_D3D12_FENCE_BIT)
-            {
-                FIXME("Queue submissions with waits on D3D12-Fence compatible timeline semaphores not supported.\n");
-                return VK_ERROR_OUT_OF_HOST_MEMORY;
-            }
+                return virtual_queue_submit(queue, submit_count, submits, fence);
         }
 
         for (k = 0; k < submits[i].signalSemaphoreCount; k++)
         {
             if (wine_semaphore_from_handle(submits[i].pSignalSemaphores[k])->handle_types &
                     VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_D3D12_FENCE_BIT)
-            {
-                FIXME("Queue submissions with signalling D3D12-Fence compatible timeline semaphores not supported.\n");
-                return VK_ERROR_OUT_OF_HOST_MEMORY;
-            }
+                return virtual_queue_submit(queue, submit_count, submits, fence);
         }
     }
 
     return thunk_vkQueueSubmit(queue, submit_count, submits, fence);
+}
+
+static NTSTATUS virtual_queue_submit2(struct VkQueue_T *queue, uint32_t submit_count, const VkSubmitInfo2 *submits, VkFence fence, bool khr)
+{
+    VkSemaphoreSubmitInfo *sem_submit_info;
+    struct queue_submit_unit *submit_unit;
+    VkSubmitInfo2 *queue_submit;
+    struct wine_semaphore *sem;
+    unsigned int i, j, k;
+    uint64_t wait_value;
+    bool device_lost;
+
+    init_virtual_queue(queue);
+
+    pthread_mutex_lock(&queue->submissions_mutex);
+    device_lost = queue->device_lost;
+    pthread_mutex_unlock(&queue->submissions_mutex);
+    if (device_lost)
+        return VK_ERROR_DEVICE_LOST;
+
+    submit_unit = malloc(sizeof(*submit_unit));
+    submit_unit->submit_count = submit_count;
+    submit_unit->submits = NULL;
+    submit_unit->submits2 = copy_VkSubmitInfo2(submits, submit_count);
+    submit_unit->fence = fence;
+    submit_unit->waits = NULL;
+    submit_unit->khr = khr;
+
+    /* As D3D12 fences are rewindable, we add the wait synchronously as not to miss a temporarily signalled value
+     between vkQueueSubmit and processing the submit unit */
+    for (i = 0, k = 0; i < submit_count; i++)
+    {
+        queue_submit = &submit_unit->submits2[i];
+
+        for (j = 0; j < queue_submit->waitSemaphoreInfoCount; j++)
+        {
+            sem_submit_info = (VkSemaphoreSubmitInfo *) &queue_submit->pWaitSemaphoreInfos[j];
+            sem = wine_semaphore_from_handle(sem_submit_info->semaphore);
+
+            if (!(sem->handle_types & VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_D3D12_FENCE_BIT))
+                continue;
+
+            wait_value = sem_submit_info->value;
+
+            submit_unit->waits = realloc(submit_unit->waits, (k + 1) * sizeof(*submit_unit->waits));
+            submit_unit->waits[k] = NULL;
+
+            d3d12_semaphore_lock(sem);
+
+            if ((sem_submit_info->value =
+                                d3d12_semaphore_try_get_wait_value_locked(sem, wait_value, queue)) == -1)
+                submit_unit->waits[k] = d3d12_semaphore_push_wait_locked(sem, wait_value);
+
+            d3d12_semaphore_unlock(sem);
+            k++;
+        }
+    }
+
+    pthread_mutex_lock(&queue->submissions_mutex);
+    queue->processing = true;
+    if (fence)
+    {
+        wine_fence_from_handle(fence)->queue = queue;
+        wine_fence_from_handle(fence)->wait_assist = true;
+    }
+    list_add_tail(&queue->submissions, &submit_unit->entry);
+    pthread_cond_signal(&queue->submissions_cond);
+    pthread_mutex_unlock(&queue->submissions_mutex);
+
+    return VK_SUCCESS;
 }
 
 static NTSTATUS vk_queue_submit_2(VkQueue queue, uint32_t submit_count, const VkSubmitInfo2 *submits, VkFence fence, bool khr)
@@ -4884,26 +5603,23 @@ static NTSTATUS vk_queue_submit_2(VkQueue queue, uint32_t submit_count, const Vk
 
     TRACE("(%p, %u, %p, %s)\n", queue, submit_count, submits, wine_dbgstr_longlong(fence));
 
+    if (is_virtual_queue(queue))
+        return virtual_queue_submit2(queue, submit_count, submits, fence, khr);
+
     for (i = 0; i < submit_count; i++)
     {
         for (k = 0; k < submits[i].waitSemaphoreInfoCount; k++)
         {
             if (wine_semaphore_from_handle(submits[i].pWaitSemaphoreInfos[k].semaphore)->handle_types &
                     VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_D3D12_FENCE_BIT)
-            {
-                FIXME("Queue submissions with waits on D3D12-Fence compatible timeline semaphores not supported.\n");
-                return VK_ERROR_OUT_OF_HOST_MEMORY;
-            }
+                return virtual_queue_submit2(queue, submit_count, submits, fence, khr);
         }
 
         for (k = 0; k < submits[i].signalSemaphoreInfoCount; k++)
         {
             if (wine_semaphore_from_handle(submits[i].pSignalSemaphoreInfos[k].semaphore)->handle_types &
                     VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_D3D12_FENCE_BIT)
-            {
-                FIXME("Queue submissions signalling D3D12-Fence compatible timeline semaphores not supported.\n");
-                return VK_ERROR_OUT_OF_HOST_MEMORY;
-            }
+                return virtual_queue_submit2(queue, submit_count, submits, fence, khr);
         }
     }
 
@@ -4972,15 +5688,23 @@ NTSTATUS wine_vkQueuePresentKHR(void *args)
 
     TRACE("%p %p\n", queue, present_info);
 
-    for (i = 0; i < present_info->waitSemaphoreCount)
+    for (i = 0; i < present_info->waitSemaphoreCount; i++)
     {
-        semaphore = wine_semaphore_from_handle(present_info->pWaitSemaphores);
+        semaphore = wine_semaphore_from_handle(present_info->pWaitSemaphores[i]);
 
         if (semaphore->handle_types & VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_D3D12_FENCE_BIT)
         {
             FIXME("Waiting on D3D12-Fence compatible timeline semaphore not supported.\n");
             return VK_ERROR_OUT_OF_HOST_MEMORY;
         }
+    }
+
+    if (is_virtual_queue(queue))
+    {
+        pthread_mutex_lock(&queue->submissions_mutex);
+        while (queue->processing)
+            pthread_cond_wait(&queue->submissions_cond, &queue->submissions_mutex);
+        pthread_mutex_unlock(&queue->submissions_mutex);
     }
 
     host_present_info.pWaitSemaphores = host_semaphores = convert_VkSemaphore_array_win_to_host(present_info->pWaitSemaphores, present_info->waitSemaphoreCount);
@@ -5002,6 +5726,15 @@ NTSTATUS wine_vkQueueBindSparse(void *args)
     unsigned int i, k;
 
     TRACE("(%p, %u, %p, 0x%s)\n", queue, bind_info_count, bind_info, wine_dbgstr_longlong(fence));
+
+    if (is_virtual_queue(queue))
+    {
+        FIXME("Can't process sparse bind calls on virtual queue, flushing.\n");
+        pthread_mutex_lock(&queue->submissions_mutex);
+        while (queue->processing)
+            pthread_cond_wait(&queue->submissions_cond, &queue->submissions_mutex);
+        pthread_mutex_unlock(&queue->submissions_mutex);
+    }
 
     for (i = 0; i < bind_info_count; i++)
     {
@@ -5031,4 +5764,22 @@ NTSTATUS wine_vkQueueBindSparse(void *args)
     }
 
     return thunk_vkQueueBindSparse(queue, bind_info_count, bind_info, fence);
+}
+
+NTSTATUS wine_vkQueueWaitIdle(void *args)
+{
+    struct vkQueueWaitIdle_params *params = args;
+    VkQueue queue = params->queue;
+
+    TRACE("(%p)\n", queue);
+
+    if (is_virtual_queue(queue))
+    {
+        pthread_mutex_lock(&queue->submissions_mutex);
+        while (queue->processing)
+            pthread_cond_wait(&queue->submissions_cond, &queue->submissions_mutex);
+        pthread_mutex_unlock(&queue->submissions_mutex);
+    }
+
+    return queue->device->funcs.p_vkQueueWaitIdle(queue->queue);
 }

--- a/dlls/winevulkan/vulkan.c
+++ b/dlls/winevulkan/vulkan.c
@@ -285,6 +285,14 @@ static struct VkPhysicalDevice_T *wine_vk_physical_device_alloc(struct VkInstanc
                     VK_KHR_EXTERNAL_MEMORY_WIN32_EXTENSION_NAME);
             host_properties[i].specVersion = VK_KHR_EXTERNAL_MEMORY_WIN32_SPEC_VERSION;
         }
+        if (!strcmp(host_properties[i].extensionName, "VK_KHR_external_semaphore_fd"))
+        {
+            TRACE("Substituting VK_KHR_external_semaphore_fd for VK_KHR_external_semaphore_win32\n");
+
+            snprintf(host_properties[i].extensionName, sizeof(host_properties[i].extensionName),
+                    VK_KHR_EXTERNAL_SEMAPHORE_WIN32_EXTENSION_NAME);
+            host_properties[i].specVersion = VK_KHR_EXTERNAL_SEMAPHORE_WIN32_SPEC_VERSION;
+        }
 
         if (wine_vk_device_extension_supported(host_properties[i].extensionName))
         {
@@ -473,7 +481,7 @@ static VkResult wine_vk_device_convert_create_info(const VkDeviceCreateInfo *src
     }
     for (i = 0; i < src->enabledExtensionCount; i++)
     {
-        if (!strcmp(src->ppEnabledExtensionNames[i], "VK_KHR_external_memory_win32"))
+        if (!strcmp(src->ppEnabledExtensionNames[i], "VK_KHR_external_memory_win32") || !strcmp(src->ppEnabledExtensionNames[i], "VK_KHR_external_semaphore_win32"))
         {
             replace_win32 = 1;
             break;
@@ -500,6 +508,8 @@ static VkResult wine_vk_device_convert_create_info(const VkDeviceCreateInfo *src
 
             if (replace_win32 && !strcmp(src->ppEnabledExtensionNames[i], "VK_KHR_external_memory_win32"))
                 new_extensions_list[o] = strdup("VK_KHR_external_memory_fd");
+            else if (replace_win32 && !strcmp(src->ppEnabledExtensionNames[i], "VK_KHR_external_semaphore_win32"))
+                new_extensions_list[o] = strdup("VK_KHR_external_semaphore_fd");
             else
                 new_extensions_list[o] = strdup(dst->ppEnabledExtensionNames[i]);
             ++o;
@@ -1747,6 +1757,51 @@ NTSTATUS wine_vkGetPhysicalDeviceCalibrateableTimeDomainsEXT(void *args)
     return res;
 }
 
+static inline void wine_vk_normalize_semaphore_handle_types_win(VkExternalSemaphoreHandleTypeFlags *types)
+{
+    *types &=
+        VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_WIN32_BIT |
+        VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_WIN32_KMT_BIT |
+        VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_D3D12_FENCE_BIT;
+}
+
+static inline void wine_vk_normalize_semaphore_handle_types_host(VkExternalSemaphoreHandleTypeFlags *types)
+{
+    *types &=
+        VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_FD_BIT |
+        VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_SYNC_FD_BIT;
+}
+
+static void wine_vk_get_physical_device_external_semaphore_properties(VkPhysicalDevice phys_dev,
+    void (*p_vkGetPhysicalDeviceExternalSemaphoreProperties)(VkPhysicalDevice, const VkPhysicalDeviceExternalSemaphoreInfo *, VkExternalSemaphoreProperties *),
+    const VkPhysicalDeviceExternalSemaphoreInfo *semaphore_info, VkExternalSemaphoreProperties *properties)
+{
+    VkPhysicalDeviceExternalSemaphoreInfo semaphore_info_dup = *semaphore_info;
+
+    wine_vk_normalize_semaphore_handle_types_win(&semaphore_info_dup.handleType);
+    if (semaphore_info_dup.handleType == VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_WIN32_BIT)
+        semaphore_info_dup.handleType = VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_FD_BIT;
+    wine_vk_normalize_semaphore_handle_types_host(&semaphore_info_dup.handleType);
+
+    if (semaphore_info->handleType && !semaphore_info_dup.handleType)
+    {
+        properties->exportFromImportedHandleTypes = 0;
+        properties->compatibleHandleTypes = 0;
+        properties->externalSemaphoreFeatures = 0;
+        return;
+    }
+
+    p_vkGetPhysicalDeviceExternalSemaphoreProperties(phys_dev->phys_dev, &semaphore_info_dup, properties);
+
+    if (properties->exportFromImportedHandleTypes & VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_FD_BIT)
+        properties->exportFromImportedHandleTypes |= VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_WIN32_BIT;
+    wine_vk_normalize_semaphore_handle_types_win(&properties->exportFromImportedHandleTypes);
+
+    if (properties->compatibleHandleTypes & VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_FD_BIT)
+        properties->compatibleHandleTypes |= VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_WIN32_BIT;
+    wine_vk_normalize_semaphore_handle_types_win(&properties->compatibleHandleTypes);
+}
+
 NTSTATUS wine_vkGetPhysicalDeviceExternalSemaphoreProperties(void *args)
 {
     struct vkGetPhysicalDeviceExternalSemaphoreProperties_params *params = args;
@@ -1755,9 +1810,8 @@ NTSTATUS wine_vkGetPhysicalDeviceExternalSemaphoreProperties(void *args)
     VkExternalSemaphoreProperties *properties = params->pExternalSemaphoreProperties;
 
     TRACE("%p, %p, %p\n", phys_dev, semaphore_info, properties);
-    properties->exportFromImportedHandleTypes = 0;
-    properties->compatibleHandleTypes = 0;
-    properties->externalSemaphoreFeatures = 0;
+    wine_vk_get_physical_device_external_semaphore_properties(phys_dev, phys_dev->instance->funcs.p_vkGetPhysicalDeviceExternalSemaphoreProperties, semaphore_info, properties);
+
     return STATUS_SUCCESS;
 }
 
@@ -1769,9 +1823,8 @@ NTSTATUS wine_vkGetPhysicalDeviceExternalSemaphorePropertiesKHR(void *args)
     VkExternalSemaphoreProperties *properties = params->pExternalSemaphoreProperties;
 
     TRACE("%p, %p, %p\n", phys_dev, semaphore_info, properties);
-    properties->exportFromImportedHandleTypes = 0;
-    properties->compatibleHandleTypes = 0;
-    properties->externalSemaphoreFeatures = 0;
+    wine_vk_get_physical_device_external_semaphore_properties(phys_dev, phys_dev->instance->funcs.p_vkGetPhysicalDeviceExternalSemaphorePropertiesKHR, semaphore_info, properties);
+
     return STATUS_SUCCESS;
 }
 
@@ -3523,6 +3576,10 @@ BOOL WINAPI wine_vk_is_available_device_function(VkDevice device, const char *na
 {
     if (!strcmp(name, "vkGetMemoryWin32HandleKHR") || !strcmp(name, "vkGetMemoryWin32HandlePropertiesKHR"))
         name = "vkGetMemoryFdKHR";
+    if (!strcmp(name, "vkGetSemaphoreWin32HandleKHR"))
+        name = "vkGetSemaphoreFdKHR";
+    if (!strcmp(name, "vkImportSemaphoreWin32HandleKHR"))
+        name = "vkImportSemaphoreFdKHR";
     return !!vk_funcs->p_vkGetDeviceProcAddr(device->device, name);
 }
 
@@ -4023,6 +4080,122 @@ NTSTATUS wine_vkCreateImage(void *args)
     res = device->funcs.p_vkCreateImage(device->device, &create_info_host, NULL, image);
 
     free_VkImageCreateInfo_struct_chain(&create_info_host);
+
+    return res;
+}
+
+NTSTATUS wine_vkCreateSemaphore(void *args)
+{
+    struct vkCreateSemaphore_params *params = args;
+    VkDevice device = params->device;
+    const VkSemaphoreCreateInfo *create_info = params->pCreateInfo;
+    const VkAllocationCallbacks *allocator = params->pAllocator;
+    VkSemaphore *semaphore = params->pSemaphore;
+
+    VkSemaphoreCreateInfo create_info_host = *create_info;
+    VkExportSemaphoreCreateInfo *export_semaphore_info;
+    VkResult res;
+
+    TRACE("%p %p %p %p", device, create_info, allocator, semaphore);
+
+    if (allocator)
+        FIXME("Support for allocation callbacks not implemented yet\n");
+
+    if ((res = convert_VkSemaphoreCreateInfo_struct_chain(create_info->pNext, &create_info_host)))
+    {
+        WARN("Failed to convert VkSemaphoreCreateInfo pNext chain, res=%d.\n", res);
+        return res;
+    }
+
+    if ((export_semaphore_info = wine_vk_find_struct(&create_info_host, EXPORT_SEMAPHORE_CREATE_INFO)))
+    {
+        if (export_semaphore_info->handleTypes & VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_WIN32_BIT)
+            export_semaphore_info->handleTypes |= VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_FD_BIT;
+        wine_vk_normalize_semaphore_handle_types_host(&export_semaphore_info->handleTypes);
+    }
+
+    if (wine_vk_find_struct(&create_info_host,  EXPORT_SEMAPHORE_WIN32_HANDLE_INFO_KHR))
+        FIXME("VkExportSemaphoreWin32HandleInfoKHR unhandled.\n");
+
+    res = device->funcs.p_vkCreateSemaphore(device->device, &create_info_host, NULL, semaphore);
+
+    free_VkSemaphoreCreateInfo_struct_chain(&create_info_host);
+
+    return res;
+}
+
+NTSTATUS wine_vkGetSemaphoreWin32HandleKHR(void *args)
+{
+    struct vkGetSemaphoreWin32HandleKHR_params *params = args;
+    VkDevice device = params->device;
+    const VkSemaphoreGetWin32HandleInfoKHR *handle_info = params->pGetWin32HandleInfo;
+    HANDLE *handle = params->pHandle;
+
+    VkSemaphoreGetFdInfoKHR_host fd_info;
+    VkResult res;
+    int fd;
+
+    fd_info.sType = VK_STRUCTURE_TYPE_SEMAPHORE_GET_FD_INFO_KHR;
+    fd_info.pNext = handle_info->pNext;
+    fd_info.semaphore = handle_info->semaphore;
+    fd_info.handleType = handle_info->handleType;
+    if (fd_info.handleType == VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_WIN32_BIT)
+        fd_info.handleType = VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_FD_BIT;
+    wine_vk_normalize_semaphore_handle_types_host(&fd_info.handleType);
+
+    res = device->funcs.p_vkGetSemaphoreFdKHR(device->device, &fd_info, &fd);
+
+    if (res != VK_SUCCESS)
+        return res;
+
+    if (wine_server_fd_to_handle(fd, GENERIC_ALL, 0, handle) != STATUS_SUCCESS)
+    {
+        close(fd);
+        return VK_ERROR_OUT_OF_HOST_MEMORY;
+    }
+
+    return VK_SUCCESS;
+}
+
+NTSTATUS wine_vkImportSemaphoreWin32HandleKHR(void *args)
+{
+    struct vkImportSemaphoreWin32HandleKHR_params *params = args;
+    VkDevice device = params->device;
+    const VkImportSemaphoreWin32HandleInfoKHR *handle_info = params->pImportSemaphoreWin32HandleInfo;
+
+    VkImportSemaphoreFdInfoKHR_host fd_info;
+    VkResult res;
+    int fd;
+
+    fd_info.sType = VK_STRUCTURE_TYPE_IMPORT_SEMAPHORE_FD_INFO_KHR;
+    fd_info.pNext = handle_info->pNext;
+    fd_info.semaphore = handle_info->semaphore;
+    fd_info.flags = handle_info->flags;
+    fd_info.handleType = handle_info->handleType;
+
+    if (fd_info.handleType == VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_WIN32_BIT)
+    {
+        if (handle_info->name)
+        {
+            FIXME("Importing win32 semaphore by name not supported.\n");
+            return VK_ERROR_INVALID_EXTERNAL_HANDLE;
+        }
+
+        fd_info.handleType = VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_FD_BIT;
+        if (wine_server_handle_to_fd(handle_info->handle, GENERIC_ALL, &fd, NULL) != STATUS_SUCCESS)
+            return VK_ERROR_INVALID_EXTERNAL_HANDLE;
+    }
+    wine_vk_normalize_semaphore_handle_types_host(&fd_info.handleType);
+
+    if (!fd_info.handleType)
+    {
+        FIXME("Importing win32 semaphore with handle type %#x not supported.\n", handle_info->handleType);
+        return VK_ERROR_INVALID_EXTERNAL_HANDLE;
+    }
+
+    /* importing FDs transfers ownership, importing NT handles does not  */
+    if ((res = device->funcs.p_vkImportSemaphoreFdKHR(device->device, &fd_info)) != VK_SUCCESS)
+        close(fd);
 
     return res;
 }

--- a/dlls/winevulkan/vulkan_private.h
+++ b/dlls/winevulkan/vulkan_private.h
@@ -331,6 +331,26 @@ static inline VkSemaphore wine_semaphore_to_handle(struct wine_semaphore *semaph
     return (VkSemaphore)(uintptr_t)semaphore;
 }
 
+struct wine_fence
+{
+    VkFence fence;
+
+    struct VkQueue_T *queue;
+    struct VkSwapchainKHR_T *swapchain;
+    bool wait_assist;
+    int eventfd;
+};
+
+static inline struct wine_fence *wine_fence_from_handle(VkFence handle)
+{
+    return (struct wine_fence *)(uintptr_t)handle;
+}
+
+static inline VkFence wine_fence_to_handle(struct wine_fence *fence)
+{
+    return (VkFence)(uintptr_t)fence;
+}
+
 BOOL wine_vk_device_extension_supported(const char *name) DECLSPEC_HIDDEN;
 BOOL wine_vk_instance_extension_supported(const char *name) DECLSPEC_HIDDEN;
 

--- a/dlls/winevulkan/vulkan_private.h
+++ b/dlls/winevulkan/vulkan_private.h
@@ -266,6 +266,33 @@ static inline VkDeviceMemory wine_dev_mem_to_handle(struct wine_dev_mem *dev_mem
     return (VkDeviceMemory)(uintptr_t)dev_mem;
 }
 
+struct wine_semaphore
+{
+    VkSemaphore semaphore;
+
+    VkExternalSemaphoreHandleTypeFlagBits handle_types;
+    VkExternalSemaphoreHandleTypeFlagBits current_type;
+    HANDLE handle;
+
+    struct wine_vk_mapping mapping;
+
+    struct
+    {
+        pthread_mutex_t mutex;
+        uint64_t virtual_value;
+    } *d3d12_fence_shm;
+};
+
+static inline struct wine_semaphore *wine_semaphore_from_handle(VkSemaphore handle)
+{
+    return (struct wine_semaphore *)(uintptr_t)handle;
+}
+
+static inline VkSemaphore wine_semaphore_to_handle(struct wine_semaphore *semaphore)
+{
+    return (VkSemaphore)(uintptr_t)semaphore;
+}
+
 BOOL wine_vk_device_extension_supported(const char *name) DECLSPEC_HIDDEN;
 BOOL wine_vk_instance_extension_supported(const char *name) DECLSPEC_HIDDEN;
 

--- a/dlls/winevulkan/vulkan_private.h
+++ b/dlls/winevulkan/vulkan_private.h
@@ -125,6 +125,8 @@ struct VkInstance_T
     struct vulkan_instance_funcs funcs;
     VkInstance instance; /* native instance */
 
+    uint32_t api_version;
+
     /* We cache devices as we need to wrap them as they are
      * dispatchable objects.
      */
@@ -151,6 +153,8 @@ struct VkPhysicalDevice_T
     struct VkInstance_T *instance; /* parent */
     VkPhysicalDevice phys_dev; /* native physical device */
 
+    uint32_t api_version;
+
     VkExtensionProperties *extensions;
     uint32_t extension_count;
 
@@ -166,6 +170,22 @@ struct VkQueue_T
     uint32_t family_index;
     uint32_t queue_index;
     VkDeviceQueueCreateFlags flags;
+
+    bool virtual_queue;
+    bool processing;
+    bool device_lost;
+
+    pthread_t virtual_queue_thread;
+    pthread_mutex_t submissions_mutex;
+    pthread_cond_t submissions_cond;
+    struct list submissions;
+
+    pthread_t signal_thread;
+    pthread_mutex_t signaller_mutex;
+    pthread_cond_t signaller_cond;
+    struct list signal_ops;
+
+    bool stop;
 
     struct wine_vk_mapping mapping;
 };
@@ -289,6 +309,15 @@ struct wine_semaphore
             uint64_t physical_value;
             pthread_cond_t cond;
         } pending_waits[100];
+
+        struct pending_update
+        {
+            uint64_t virtual_value;
+            uint64_t physical_value;
+            pid_t signalling_pid;
+            struct VkQueue_T *signalling_queue;
+        } pending_updates[100];
+        uint32_t pending_updates_count;
     } *d3d12_fence_shm;
 };
 

--- a/dlls/winevulkan/vulkan_private.h
+++ b/dlls/winevulkan/vulkan_private.h
@@ -27,6 +27,7 @@
 #define VK_NO_PROTOTYPES
 
 #include <pthread.h>
+#include <stdbool.h>
 
 #include "wine/list.h"
 
@@ -279,7 +280,15 @@ struct wine_semaphore
     struct
     {
         pthread_mutex_t mutex;
-        uint64_t virtual_value;
+        uint64_t virtual_value, physical_value, counter;
+
+        struct pending_wait
+        {
+            bool present, satisfied;
+            uint64_t virtual_value;
+            uint64_t physical_value;
+            pthread_cond_t cond;
+        } pending_waits[100];
     } *d3d12_fence_shm;
 };
 

--- a/dlls/winevulkan/vulkan_private.h
+++ b/dlls/winevulkan/vulkan_private.h
@@ -333,4 +333,16 @@ static inline void init_unicode_string( UNICODE_STRING *str, const WCHAR *data )
     str->Buffer = (WCHAR *)data;
 }
 
+static inline void *memdup(const void *in, size_t number, size_t size)
+{
+    void *out;
+
+    if (!in)
+        return NULL;
+
+    out = malloc(number * size);
+    memcpy(out, in, number * size);
+    return out;
+}
+
 #endif /* __WINE_VULKAN_PRIVATE_H */

--- a/dlls/winex11.drv/event.c
+++ b/dlls/winex11.drv/event.c
@@ -853,7 +853,9 @@ static BOOL X11DRV_FocusIn( HWND hwnd, XEvent *xev )
     }
 
     /* ask the foreground window to re-apply the current ClipCursor rect */
-    SendMessageW( GetForegroundWindow(), WM_X11DRV_CLIP_CURSOR_REQUEST, 0, 0 );
+    if (!SendMessageTimeoutW( GetForegroundWindow(), WM_X11DRV_CLIP_CURSOR_REQUEST, 0, 0,
+                              SMTO_NOTIMEOUTIFNOTHUNG, 500, NULL ) && GetLastError() == ERROR_TIMEOUT)
+        ERR( "WM_X11DRV_CLIP_CURSOR_REQUEST timed out.\n" );
 
     /* ignore wm specific NotifyUngrab / NotifyGrab events w.r.t focus */
     if (event->mode == NotifyGrab || event->mode == NotifyUngrab) return FALSE;

--- a/include/mfapi.h
+++ b/include/mfapi.h
@@ -534,6 +534,8 @@ HRESULT WINAPI MFCreateMediaEvent(MediaEventType type, REFGUID extended_type, HR
 HRESULT WINAPI MFCreateMediaType(IMFMediaType **type);
 HRESULT WINAPI MFCreateMFVideoFormatFromMFMediaType(IMFMediaType *media_type, MFVIDEOFORMAT **video_format, UINT32 *size);
 HRESULT WINAPI MFCreateSample(IMFSample **sample);
+HRESULT WINAPI MFCreateTempFile(MF_FILE_ACCESSMODE accessmode, MF_FILE_OPENMODE openmode, MF_FILE_FLAGS flags,
+        IMFByteStream **bytestream);
 HRESULT WINAPI MFCreateVideoMediaTypeFromSubtype(const GUID *subtype, IMFVideoMediaType **media_type);
 HRESULT WINAPI MFCreateVideoSampleAllocatorEx(REFIID riid, void **allocator);
 HRESULT WINAPI MFCreateMemoryBuffer(DWORD max_length, IMFMediaBuffer **buffer);

--- a/programs/wineboot/wineboot.c
+++ b/programs/wineboot/wineboot.c
@@ -317,7 +317,7 @@ static UINT64 read_tsc_frequency( BOOL has_rdtscp )
             freq1 = (tsc3 - tsc1) * 10000000 / (time1 - time0);
             error = llabs( (freq1 - freq0) * 1000000 / min( freq1, freq0 ) );
         }
-        while (error > 100 && --retries);
+        while (error > 500 && --retries);
 
         if (!retries) WARN( "TSC frequency calibration failed, unstable TSC?\n" );
         else

--- a/programs/wineboot/wineboot.c
+++ b/programs/wineboot/wineboot.c
@@ -319,7 +319,13 @@ static UINT64 read_tsc_frequency( BOOL has_rdtscp )
         }
         while (error > 500 && --retries);
 
-        if (!retries) WARN( "TSC frequency calibration failed, unstable TSC?\n" );
+        if (!retries)
+        {
+            FIXME( "TSC frequency calibration failed, unstable TSC?");
+            FIXME( "time0 %I64u ns, time1 %I64u ns\n", time0 * 100, time1 * 100 );
+            FIXME( "tsc2 - tsc0 %I64u, tsc3 - tsc1 %I64u\n", tsc2 - tsc0, tsc3 - tsc1 );
+            FIXME( "freq0 %I64u Hz, freq2 %I64u Hz, error %I64u ppm\n", freq0, freq1, error );
+        }
         else
         {
             freq = (freq0 + freq1) / 2;

--- a/server/mapping.c
+++ b/server/mapping.c
@@ -160,6 +160,7 @@ struct type_descr mapping_type =
 struct mapping
 {
     struct object   obj;             /* object header */
+    struct list     kernel_object;   /* list of kernel object pointers */
     mem_size_t      size;            /* mapping size */
     unsigned int    flags;           /* SEC_* flags */
     struct fd      *fd;              /* fd for mapped file */
@@ -171,6 +172,7 @@ struct mapping
 
 static void mapping_dump( struct object *obj, int verbose );
 static struct fd *mapping_get_fd( struct object *obj );
+static struct list *mapping_get_kernel_obj_list( struct object *obj );
 static void mapping_destroy( struct object *obj );
 static enum server_fd_type mapping_get_fd_type( struct fd *fd );
 
@@ -195,7 +197,7 @@ static const struct object_ops mapping_ops =
     directory_link_name,         /* link_name */
     default_unlink_name,         /* unlink_name */
     no_open_file,                /* open_file */
-    no_kernel_obj_list,          /* get_kernel_obj_list */
+    mapping_get_kernel_obj_list, /* get_kernel_obj_list */
     no_close_handle,             /* close_handle */
     mapping_destroy              /* destroy */
 };
@@ -903,6 +905,8 @@ static struct mapping *create_mapping( struct object *root, const struct unicode
     if (get_error() == STATUS_OBJECT_NAME_EXISTS)
         return mapping;  /* Nothing else to do */
 
+    list_init( &mapping->kernel_object );
+
     mapping->size        = size;
     mapping->fd          = NULL;
     mapping->shared      = NULL;
@@ -994,6 +998,8 @@ struct mapping *create_fd_mapping( struct object *root, const struct unicode_str
 
     if (!(mapping = create_named_object( root, &mapping_ops, name, attr, sd ))) return NULL;
     if (get_error() == STATUS_OBJECT_NAME_EXISTS) return mapping;  /* Nothing else to do */
+
+    list_init( &mapping->kernel_object );
 
     mapping->shared    = NULL;
     mapping->committed = NULL;
@@ -1099,6 +1105,12 @@ static struct fd *mapping_get_fd( struct object *obj )
 {
     struct mapping *mapping = (struct mapping *)obj;
     return (struct fd *)grab_object( mapping->fd );
+}
+
+static struct list *mapping_get_kernel_obj_list( struct object *obj )
+{
+    struct mapping *mapping = (struct mapping *)obj;
+    return &mapping->kernel_object;
 }
 
 static void mapping_destroy( struct object *obj )

--- a/server/protocol.def
+++ b/server/protocol.def
@@ -3870,6 +3870,8 @@ enum esync_type
 @REQ(get_esync_apc_fd)
 @END
 
+#define FSYNC_SHM_PAGE_SIZE 0x10000
+
 enum fsync_type
 {
     FSYNC_SEMAPHORE = 1,


### PR DESCRIPTION
Putting up this MR up for winevulkan review of the timeline semaphore commits.  We virtualise the semaphores and the queues to implement a system similar to VKD3D-Proton's in which we implement wait-before-signal and rewinding ourselves.  DXVK and VKD3D-Proton them implement their shared fence objects on top of this.